### PR TITLE
Chore: add script to easily sync repositories

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -28,7 +28,7 @@ fi
 
 REMOTE=`git remote -v`
 
-if [[ $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (fetch)"* 
+if [[ $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (fetch)"*
     && $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (push)"* ]];
 then
     echo "Upstream found..."

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#usage on terminal: sh sync.sh [branch to sync]
+#if no branch is specified, master is used as default.
+
+if [[ $1 == "" ]];
+then
+	echo "Branch to sync defaulted to master."
+	BRANCH_TO_SYNC="master"
+else
+	BRANCH_TO_SYNC=$1
+fi
+
+BRANCH_EXIST=$(git branch --list $BRANCH_TO_SYNC)
+
+if [[ -z ${BRANCH_EXIST} ]]; then
+    echo "Branch to sync does not exist."
+    exit
+fi
+
+CURRENT_BRANCH=`git branch`
+
+if [[ $CURRENT_BRANCH != *"*	master"* ]];
+then
+	echo "Switching to branch master..."
+	git checkout master
+fi
+
+REMOTE=`git remote -v`
+
+if [[ $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (fetch)"* 
+    && $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (push)"* ]];
+then
+    echo "Upstream found..."
+else
+    echo "Upstream not found"
+    echo "Adding upstream..."
+    git remote add upstream https://github.com/AY2021S2-CS2103T-T12-4/tp.git
+fi
+
+echo "Fetching upstream..."
+git fetch upstream
+echo "Merging upstream with master..."
+git merge upstream/master
+echo "Pushing local master to remote repository..."
+git push
+

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -13,7 +13,7 @@ fi
 
 BRANCH_EXIST=$(git branch --list $BRANCH_TO_SYNC)
 
-if [[ -z ${BRANCH_EXIST} ]]; 
+if [[ -z ${BRANCH_EXIST} ]];
 then
     echo "Branch to sync does not exist."
     exit

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -23,8 +23,8 @@ CURRENT_BRANCH=`git branch`
 
 if [[ $CURRENT_BRANCH != *"*	$BRANCH_TO_SYNC"* ]];
 then
-	echo "Switching to branch master..."
-	git checkout master
+	echo "Switching to branch $BRANCH_TO_SYNC..."
+	git checkout $BRANCH_TO_SYNC
 fi
 
 REMOTE=`git remote -v`

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -5,10 +5,10 @@
 
 if [[ $1 == "" ]];
 then
-	echo "Branch to sync defaulted to master."
-	BRANCH_TO_SYNC="master"
+    echo "Branch to sync defaulted to master."
+    BRANCH_TO_SYNC="master"
 else
-	BRANCH_TO_SYNC=$1
+    BRANCH_TO_SYNC=$1
 fi
 
 BRANCH_EXIST=$(git branch --list $BRANCH_TO_SYNC)
@@ -21,16 +21,20 @@ fi
 
 CURRENT_BRANCH=`git branch`
 
-if [[ $CURRENT_BRANCH != *"*	$BRANCH_TO_SYNC"* ]];
+if [[ $CURRENT_BRANCH != *"*    $BRANCH_TO_SYNC"* ]];
 then
-	echo "Switching to branch $BRANCH_TO_SYNC..."
-	git checkout $BRANCH_TO_SYNC
+    echo "Switching to branch $BRANCH_TO_SYNC..."
+    git checkout $BRANCH_TO_SYNC
+    if [ ! $? -eq 0 ]; then
+        echo "Unable to switch branch."
+        exit
+    fi
 fi
 
 REMOTE=`git remote -v`
 
-if [[ $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (fetch)"*
-    && $REMOTE == *"upstream	https://github.com/AY2021S2-CS2103T-T12-4/tp.git (push)"* ]];
+if [[ $REMOTE == *"upstream https://github.com/AY2021S2-CS2103T-T12-4/tp.git (fetch)"*
+    && $REMOTE == *"upstream    https://github.com/AY2021S2-CS2103T-T12-4/tp.git (push)"* ]];
 then
     echo "Upstream found..."
 else
@@ -41,7 +45,11 @@ fi
 
 echo "Fetching upstream..."
 git fetch upstream
-echo "Merging upstream with master..."
+echo "Merging upstream master with local branch $BRANCH_TO_SYNC..."
 git merge upstream/master
+if [ ! $? -eq 0 ]; then
+    echo "Unable to merge branch."
+    exit
+fi
 echo "Pushing local master to remote repository..."
 git push

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -44,4 +44,3 @@ echo "Merging upstream with master..."
 git merge upstream/master
 echo "Pushing local master to remote repository..."
 git push
-

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -13,14 +13,15 @@ fi
 
 BRANCH_EXIST=$(git branch --list $BRANCH_TO_SYNC)
 
-if [[ -z ${BRANCH_EXIST} ]]; then
+if [[ -z ${BRANCH_EXIST} ]]; 
+then
     echo "Branch to sync does not exist."
     exit
 fi
 
 CURRENT_BRANCH=`git branch`
 
-if [[ $CURRENT_BRANCH != *"*	master"* ]];
+if [[ $CURRENT_BRANCH != *"*	$BRANCH_TO_SYNC"* ]];
 then
 	echo "Switching to branch master..."
 	git checkout master


### PR DESCRIPTION
Add script to easily sync local, remote and team repositories.

Usage on terminal:
`sh sync [local branch to sync]`

If a branch is not specified, the default branch used will be `master`.

Closes #43 