### PR TITLE
Docs: update developer guide and add user stories and use cases

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -35,7 +35,7 @@ AB3 DG links here for references:
 * save requests for quick execution again
 * general analysis/recommendation system based on certain metrics
 * no need to create any account
-* easy to get started
+* simple and easy to get started
 * unintrusive
 * great user experience
 
@@ -47,12 +47,15 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | -------- | ------------------------------------------ | ------------------------------ | --------------------------------------------------|
 | `* * *`  | new user                                   | view a quick description of APIs| quickly review the concepts of APIs              |
 | `* * *`  | long time user                             | test my APIs on the fly               | run API tests anytime                      |
-| `* * *`  | long-term user                             | quickly load my previous APIs |  save time and not have to type them all out again |
+| `* * *`  | long time user                             | quickly load my previous APIs |  save time and not have to type them all out again |
 | `* * *`  | experienced developer                      | test out my API multiple times repeatedly |  know if my API can cope under significant traffic |
 | `* * *`  | new API developer                          | clear error messages                | quickly learn where I went wrong             |
 | `* * *`  | API tester                                 | a focused simple design          | quickly validate the state of an endpoint       |
 | `* * *`  | new user                                   | have an optional features walkthrough   | have a broad overview of functionalities |
+| `* * *`      | moderate user                            | find/locate saved API endpoints | can easily view the information for the endpoint of my interest      |
+| `*`      | experienced developer                      | export my saved API endpoints | can easily port or integrate the data with other platforms     |
 | `*`      | expert user                                | have API recommendations | help to optimise or are more suited for my product      |
+| `*`      | moderate user                              | learn to optimise my usage | can have a faster and smoother workflow      |
 
 
 *{More to be added}*
@@ -61,56 +64,76 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 (For all use cases below, the **System** is the `ImPoster` and the **Actor** is the `user`, unless specified otherwise)
 
-**Use case: Add an API route**
+**Use case: Add an API endpoint**
 
 **MSS**
 
-1.  User inputs formatted command 
-2.  ImPoster adds the command
+1.  User enters command to save an API endpoint
+2.  ImPoster saves the API endpoint
 
     Use case ends.
 
 **Extensions**
 
-* 2a. The given command is invalid.
+* 2a. The given command/format is invalid
 
-    * 2a1. ImPoster shows an error message.
+    * 2a1. ImPoster shows an error message
 
       Use case resumes at step 1.
 
-**Use case: Locate an saved API by name**
+**Use case: Locate a saved API endpoint by name**
 
 **MSS**
 
-1.  User inputs formatted command 
+1.  User enters command to locate a saved API endpoint
 2.  ImPoster searches the existing records
-3.  ImPoster returns all matching API records
+3.  ImPoster returns a list of matching API endpoints
 
     Use case ends.
 
 **Extensions**
 
-* 2a. The given search result is empty.
+* 2a. The given search result is empty
 
-    * 2a1. ImPoster shows a friendly message about mistyped keywords.
+    * 2a1. ImPoster shows a friendly message about mistyped keywords
 
       Use case resumes at step 1.
 
-**Use case: Run a saved API**
+**Use case: Call a saved API endpoint**
 
 **MSS**
 
-1.  User inputs formatted command calling on a saved API
-2.  ImPoster runs the API
-3.  ImPoster saves the outputs in a file that the user can view
+1.  User enters command to call a saved API endpoint
+2.  ImPoster makes a call to the desired API endpoint
+3.  API call is successful and response is shown to the user
+4.  ImPoster saves the response to a file that the user can view
 
     Use case ends.
 
 **Extensions**
 
-* 2a. There is no return result as the API call resulted in an error.
+* 2a. ImPoster receives a status code indicating an error
 
-    * 2a1. ImPoster shows a message informing the user that an error has occured.
+    * 2a1. ImPoster forwards and shows the error message (from the server, if any) to the user
+
+      Use case resumes at step 1.
+
+**Use case: Call an API endpoint directly without saving**
+
+**MSS**
+
+1.  User enters command to call an API endpoint
+2.  ImPoster makes a call to the desired API endpoint
+3.  API call is successful and response is shown to the user
+4.  ImPoster saves the response to a file that the user can view
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. ImPoster receives a status code indicating an error
+
+    * 2a1. ImPoster forwards and shows the error message (from the server, if any) to the user
 
       Use case resumes at step 1.
 
@@ -119,7 +142,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ### Non-Functional Requirements
 
 1.  Should work on any _mainstream OS_ as long as it has Java `11` or above installed.
-2.  Should be able to hold up to 1000 persons without a noticeable sluggishness in performance for typical usage.
+2.  Should be able to hold up to 1000 API endpoints without a noticeable sluggishness in performance for typical usage.
 3.  A user with above average typing speed for regular English text (i.e. not code, not system admin commands) should be able to accomplish most of the tasks faster using commands than using the mouse.
 
 *{More to be added}*
@@ -127,6 +150,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 ### Glossary
 
 * **Mainstream OS**: Windows, Linux, Unix, OS-X
-* **Private contact detail**: A contact detail that is not meant to be shared with others
+* **API endpoint**: The point of entry in a communication channel for two systems to interact
 
 *{More to be added}*


### PR DESCRIPTION
Tidy up developer guide to standardise the following:

1) No fullstops after each bullet point
2) API route -> API endpoint

Add user stories and use cases.
Miscellaneous updates as well to phrasing, NFR and glossary.

Closes #70 