### PR TITLE
Chore: add githook to ensure checkstyle and test passes locally before commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,7 @@ echo "Running pre-commit checkstyle test..."
 # checkstyle test exit code
 CHECKSTYLE_RESULT=$?
 
-if [ ! $CHECKSTYLE_RESULT -eq 0 ]; 
+if [ ! $CHECKSTYLE_RESULT -eq 0 ];
 then
     echo "Commit abandoned as checkstyle test failed."
     exit $CHECKSTYLE_RESULT
@@ -26,7 +26,7 @@ echo "Running pre-commit test cases..."
 # test cases exit code
 TEST_RESULT=$?
 
-if [ ! $TEST_RESULT -eq 0 ]; 
+if [ ! $TEST_RESULT -eq 0 ];
 then
     echo "Commit abandoned as test cases failed."
     exit $TEST_RESULT

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,39 @@
+#!/bin/sh
+# To use, place this file within the .githooks folder
+# and run the following command from the project root:
+# git config --local core.hooksPath .githooks/
+
+# stash unstaged files
+git stash --keep-index
+
+# run checkstyle test
+echo "Running pre-commit checkstyle test..."
+./gradlew checkstyleMain checkstyleTest
+
+# checkstyle test exit code
+CHECKSTYLE_RESULT=$?
+
+if [ ! $CHECKSTYLE_RESULT -eq 0 ]; 
+then
+    echo "Commit abandoned as checkstyle test failed."
+    exit $CHECKSTYLE_RESULT
+fi
+
+# run test cases
+echo "Running pre-commit test cases..."
+./gradlew test
+
+# test cases exit code
+TEST_RESULT=$?
+
+if [ ! $TEST_RESULT -eq 0 ]; 
+then
+    echo "Commit abandoned as test cases failed."
+    exit $TEST_RESULT
+fi
+
+# unstash unstaged files
+git stash pop
+
+# pass both checkstyle test and test cases
+exit 0


### PR DESCRIPTION
Add pre-commit hook to ensure checkstyle test and test cases are passing before a commit is allowed. This will achieve the following:
- In the event that github actions fail like earlier today, commits still minimally pass local tests and checks (which should translate to passing the CI on the remote as well).

- Reduce unnecessary commits clutter for fixing checkstyle or test errors.

- There is a limit to github actions on a free organisation and although we are unlikely to hit it, this still reduces the use of github actions and is generally good practice.

To use, update the master branch and simply run the command in the project repository (similar instruction is given at the top of the file in comments as well):
`git config --local core.hooksPath .githooks/`

Future `git commit` will now automatically trigger checks for checkstyle and test cases.
Closes #97 