### PR TITLE
Add time taken as an attribute of response

### DIFF
--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -37,10 +37,16 @@ public class GetRequest extends Request {
         CloseableHttpClient httpClient = HttpClients.createDefault();
         CloseableHttpResponse response;
         String responseEntity = "";
-
+        double responseTimeInSecond = 0;
         try {
             HttpGet request = new HttpGet(this.getAddress());
+            //to-do
+            //abstract timing into a function
+            long start = System.nanoTime();
             response = httpClient.execute(request);
+            long end = System.nanoTime();
+            long duration = end - start;
+            responseTimeInSecond = (double) duration / 1_000_000_000;
 
             try {
                 HttpEntity entity = response.getEntity();
@@ -59,6 +65,8 @@ public class GetRequest extends Request {
         return new Response(response.getProtocolVersion().toString(),
                 String.valueOf(response.getStatusLine().getStatusCode()),
                 response.getStatusLine().getReasonPhrase(),
-                response.getStatusLine().toString(), responseEntity);
+                response.getStatusLine().toString(),
+                responseEntity,
+                responseTimeInSecond + "");
     }
 }

--- a/src/main/java/seedu/us/among/model/endpoint/Response.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Response.java
@@ -22,6 +22,7 @@ public class Response {
     public final String reasonPhrase;
     public final String statusLine;
     public final String responseEntity;
+    public final String responseTime;
 
     /**
      * Constructs an empty {@code Response}.
@@ -32,6 +33,7 @@ public class Response {
         this.reasonPhrase = "";
         this.statusLine = "";
         this.responseEntity = "";
+        this.responseTime = "";
     }
 
     /**
@@ -43,7 +45,7 @@ public class Response {
      * @param statusLine Contains protocolVersion, statusCode and reasonPhrase.
      */
     public Response(String protocolVersion, String statusCode, String reasonPhrase, String statusLine,
-                String responseEntity) {
+                String responseEntity, String responseTime) {
         requireAllNonNull(protocolVersion, statusCode, reasonPhrase, statusLine);
         checkArgument(isValidResponse(protocolVersion, statusCode, reasonPhrase, statusLine), MESSAGE_CONSTRAINTS);
         this.protocolVersion = protocolVersion;
@@ -51,6 +53,7 @@ public class Response {
         this.reasonPhrase = reasonPhrase;
         this.statusLine = statusLine;
         this.responseEntity = responseEntity;
+        this.responseTime = responseTime;
     }
 
     /**
@@ -84,9 +87,16 @@ public class Response {
         return this.responseEntity;
     }
 
+    public String getResponseTime() {
+        return this.responseTime;
+    }
+
     @Override
     public String toString() {
-        return getProtocolVersion()
+        return "Time Taken: "
+                + getResponseTime()
+                + " seconds; "
+                + getProtocolVersion()
                 + "; Status Code: "
                 + getStatusCode()
                 + "; Reason Phrase: "

--- a/src/main/java/seedu/us/among/storage/JsonAdaptedEndpoint.java
+++ b/src/main/java/seedu/us/among/storage/JsonAdaptedEndpoint.java
@@ -60,7 +60,8 @@ class JsonAdaptedEndpoint {
                 sourceResponse.getStatusCode(),
                 sourceResponse.getReasonPhrase(),
                 sourceResponse.getStatusLine(),
-                sourceResponse.getResponseEntity());
+                sourceResponse.getResponseEntity(),
+                sourceResponse.getResponseTime());
     }
 
     /**
@@ -99,7 +100,8 @@ class JsonAdaptedEndpoint {
             Response newModelResponse = response.toModelType();
             modelResponse = new Response(newModelResponse.getProtocolVersion(),
                     newModelResponse.getStatusCode(), newModelResponse.getReasonPhrase(),
-                    newModelResponse.getStatusLine(), newModelResponse.getResponseEntity());
+                    newModelResponse.getStatusLine(), newModelResponse.getResponseEntity(),
+                    newModelResponse.getResponseTime());
         }
 
         final Set<Tag> modelTags = new HashSet<>(endpointTags);

--- a/src/main/java/seedu/us/among/storage/JsonAdaptedResponse.java
+++ b/src/main/java/seedu/us/among/storage/JsonAdaptedResponse.java
@@ -16,6 +16,7 @@ class JsonAdaptedResponse {
     private final String reasonPhrase;
     private final String statusLine;
     private final String responseEntity;
+    private final String responseTime;
 
     /**
      * Constructs a {@code JsonAdaptedResponse} with the given {@code protocolVersion, @code statusCode,
@@ -26,12 +27,15 @@ class JsonAdaptedResponse {
                                @JsonProperty("statusCode") String statusCode,
                                @JsonProperty("reasonPhrase") String reasonPhrase,
                                @JsonProperty("statusLine") String statusLine,
-                               @JsonProperty("responseEntity") String responseEntity) {
+                               @JsonProperty("responseEntity") String responseEntity,
+                               @JsonProperty("responseTime") String responseTime) {
         this.protocolVersion = protocolVersion;
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
         this.statusLine = statusLine;
         this.responseEntity = responseEntity;
+        this.responseTime = responseTime;
+
     }
 
     /**
@@ -43,6 +47,7 @@ class JsonAdaptedResponse {
         this.reasonPhrase = source.getReasonPhrase();
         this.statusLine = source.getStatusLine();
         this.responseEntity = source.getResponseEntity();
+        this.responseTime = source.getResponseTime();
     }
 
     /**
@@ -54,7 +59,7 @@ class JsonAdaptedResponse {
         if (!Response.isValidResponse(protocolVersion, statusCode, reasonPhrase, statusLine)) {
             throw new IllegalValueException(Response.MESSAGE_CONSTRAINTS);
         }
-        return new Response(protocolVersion, statusCode, reasonPhrase, statusLine, responseEntity);
+        return new Response(protocolVersion, statusCode, reasonPhrase, statusLine, responseEntity, responseTime);
     }
 
 }


### PR DESCRIPTION
fixes #133 
- A small update to get me into the flow lol
- Track the response time in seconds and store it as part of the response model
- right now it is simply displayed along with other response details (see below)
![image](https://user-images.githubusercontent.com/41845017/110211910-c730de80-7ed3-11eb-99de-0bec240c1543.png)
