### PR TITLE
Refactor response to store and display pretty printed json string

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/JsonUtil.java
@@ -111,6 +111,17 @@ public class JsonUtil {
     }
 
     /**
+     * Converts a given string representation of a HTTP entity into its pretty formatted
+     * JSON data string representation
+     * @param httpEntityString The String representation of a HTTP entity to be converted into the JSON string
+     * @return JSON data representation of the given HTTP entity, in string
+     */
+    public static String toPrettyPrintJsonString(String httpEntityString) throws IOException {
+        Object jsonObject = fromJsonString(httpEntityString, Object.class);
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
+    }
+
+    /**
      * Contains methods that retrieve logging level from serialized string.
      */
     private static class LevelDeserializer extends FromStringDeserializer<Level> {

--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -9,6 +9,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
+import seedu.us.among.commons.util.JsonUtil;
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.Response;
 
@@ -37,7 +38,7 @@ public class GetRequest extends Request {
         CloseableHttpClient httpClient = HttpClients.createDefault();
         CloseableHttpResponse response;
         String responseEntity = "";
-        double responseTimeInSecond = 0;
+        double responseTimeInSecond;
         try {
             HttpGet request = new HttpGet(this.getAddress());
             //to-do
@@ -53,6 +54,7 @@ public class GetRequest extends Request {
                 if (entity != null) {
                     //return data as string
                     responseEntity = EntityUtils.toString(entity);
+                    responseEntity = JsonUtil.toPrettyPrintJsonString(responseEntity);
                 }
 
             } finally {


### PR DESCRIPTION
fixes #138 
- include a util method to convert HTTP entity string into a pretty JSON string
- the pretty formatted string will be stored as part of the response
- this allows easy retrieval and printing of the main response body later on
- the main difference between the stored string vs the previous version is that `\n` is added accordingly so that when printing it is properly separated. I think this may add a little bit in term of storage space but the difference is very minor and can be safely ignored.
- for now, it is printed in the display as it is with the other meta information, which I will tackle next
![image](https://user-images.githubusercontent.com/41845017/110225685-d428ee80-7f22-11eb-93d6-a0028eeb9d7c.png)
