### PR TITLE
Feat: add thread to handle UI update for showing command execution progress

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -61,8 +61,6 @@ public class SendCommand extends Command {
             throw new CommandException(MESSAGE_CALL_ENDPOINT_FAILED);
         }
 
-        System.out.println(response);
-
         Endpoint endpointWithResponse = createEndpointWithResponse(endpointToSend, response);
 
         model.setEndpoint(endpointToSend, endpointWithResponse);

--- a/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
@@ -56,6 +56,13 @@ public class EndpointCaller {
             break;
         }
 
+        //mimics delay in API call, comment out if necessary //to-do Tan Jin remove after testing
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            //try-catch to allow thread to sleep
+        }
+
         return response;
     }
 }

--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -1,6 +1,7 @@
 package seedu.us.among.ui;
 
 import javafx.collections.ObservableList;
+import javafx.concurrent.Task;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
@@ -32,10 +33,9 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
-     * Handles the Enter button pressed event.
+     * Handles the command received in new thread
      */
-    @FXML
-    private void handleCommandEntered() {
+    private void handleCommandInNewThread() {
         String commandText = commandTextField.getText();
         if (commandText.equals("")) {
             return;
@@ -47,6 +47,21 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
+    }
+
+    /**
+     * Handles the Enter button pressed event.
+     */
+    @FXML
+    private void handleCommandEntered() {
+        //handle all command input in new thread
+        Task<Void> task = new Task<>() {
+            @Override public Void call() {
+                handleCommandInNewThread();
+                return null;
+            }
+        };
+        new Thread(task).start();
     }
 
     /**

--- a/src/main/java/seedu/us/among/ui/EndpointListPanel.java
+++ b/src/main/java/seedu/us/among/ui/EndpointListPanel.java
@@ -2,6 +2,7 @@ package seedu.us.among.ui;
 
 import java.util.logging.Logger;
 
+import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -41,7 +42,7 @@ public class EndpointListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new EndpointCard(endpoint, getIndex() + 1).getRoot());
+                Platform.runLater(() -> setGraphic(new EndpointCard(endpoint, getIndex() + 1).getRoot()));
             }
         }
     }


### PR DESCRIPTION
This PR does not add a loading spinner but it minimally updates the UI with a visible progress message during the execution of a command. I propose that a new issue be created for adding loading spinner as an enhancement given there are many other more important functionalities to work on.

This PR addresses the following:
- Command executions are now handled on a new thread, thus free-ing up the UI
- A simple progress message (also handled on a new thread) is now shown to the user during command execution

An example of the `send 7` command:
![demo-send-2](https://user-images.githubusercontent.com/43908963/110283554-3a913800-801b-11eb-80c9-19d77f4a2716.gif)

I am of the opinion that there can still be further improvements to its implementation/code quality. Kindly advice if anyone has suggestions.

Closes #140 