### PR TITLE
Fix response time saving bug

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/StringUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/StringUtil.java
@@ -74,4 +74,12 @@ public class StringUtil {
         return String.format("%.03f", value);
     }
 
+    /**
+     * Returns a number with seconds following it, in string
+     */
+    public static String getResponseTimeInString(Double value) {
+        requireNonNull(value);
+        return String.format("%s seconds", get3DecimalPlace(value));
+    }
+
 }

--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -70,6 +70,6 @@ public class GetRequest extends Request {
                 response.getStatusLine().getReasonPhrase(),
                 response.getStatusLine().toString(),
                 responseEntity,
-                StringUtil.get3DecimalPlace(responseTimeInSecond));
+                StringUtil.getResponseTimeInString(responseTimeInSecond));
     }
 }

--- a/src/main/java/seedu/us/among/model/endpoint/Response.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Response.java
@@ -88,7 +88,7 @@ public class Response {
     }
 
     public String getResponseTime() {
-        return String.format("%s seconds", this.responseTime);
+        return this.responseTime;
     }
 
     @Override


### PR DESCRIPTION
- Bug fix as requested by @JulietTeoh 
- Response time was added with the word "seconds" in the model's getResponse() but it is causing duplication when updating the timing
- Change to saving the response time as a string with "seconds". So now response time will be saved like this: "1.223 seconds"

Fixes #159 
