### PR TITLE
Fix: fix exit command bug along with ui lag and spam input

### DIFF
--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -44,6 +44,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
+            commandTextField.setDisable(false);
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
@@ -54,6 +55,8 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleCommandEntered() {
+        commandTextField.setDisable(true);
+
         //handle all command input in new thread
         Task<Void> task = new Task<>() {
             @Override public Void call() {

--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -44,9 +44,10 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-            commandTextField.setDisable(false);
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } finally {
+            commandTextField.setDisable(false);
         }
     }
 

--- a/src/main/java/seedu/us/among/ui/EndpointListPanel.java
+++ b/src/main/java/seedu/us/among/ui/EndpointListPanel.java
@@ -39,8 +39,10 @@ public class EndpointListPanel extends UiPart<Region> {
             super.updateItem(endpoint, empty);
 
             if (empty || endpoint == null) {
-                setGraphic(null);
-                setText(null);
+                Platform.runLater(() -> {
+                    setGraphic(null);
+                    setText(null);
+                });
             } else {
                 Platform.runLater(() -> setGraphic(new EndpointCard(endpoint, getIndex() + 1).getRoot()));
             }

--- a/src/main/java/seedu/us/among/ui/MainWindow.java
+++ b/src/main/java/seedu/us/among/ui/MainWindow.java
@@ -164,8 +164,10 @@ public class MainWindow extends UiPart<Stage> {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
                 (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
-        helpWindow.hide();
-        primaryStage.hide();
+        Platform.runLater(() -> {
+            helpWindow.hide();
+            primaryStage.hide();
+        });
     }
 
     public EndpointListPanel getEndpointListPanel() {
@@ -203,12 +205,12 @@ public class MainWindow extends UiPart<Stage> {
             public void run() {
                 Runnable updater = () -> updateProgress();
                 while (MainWindow.getProgress()) {
+                    Platform.runLater(updater);
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException ex) {
                         //try-catch to allow thread to sleep
                     }
-                    Platform.runLater(updater);
                 }
             }
         });


### PR DESCRIPTION
Resolved the issue with exit command not closing application.
Resolved the 1 second lag experienced when entering command after the UI threading update.
Add disabling of command line upon a successful input to prevent users from spamming input (which can throw an error due to excessive thread creation).
Add a quick fix for remove command threading issue as well.

Fixes #158 