### PR TITLE
Feat: add support for post request

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
@@ -1,0 +1,29 @@
+package seedu.us.among.commons.util;
+
+import java.util.HashMap;
+import java.util.Set;
+
+import seedu.us.among.model.endpoint.header.Header;
+
+/**
+ * Helper function for retrieving key-value from header strings.
+ */
+public class HeaderUtil {
+
+    /**
+     * Converts hashset of headers to a hashmap of header key-value pair.
+     *
+     * @param headerSet set of headers from endpoint
+     * @return hashmap of header key-value pair
+     */
+    public static HashMap<String, String> parseHeaders(Set<Header> headerSet) {
+        HashMap<String, String> headerMap = new HashMap<>();
+        for (Header header : headerSet) {
+            String headerString = header.toString();
+            String[] headerPair = headerString.split(":", 2);
+            assert headerPair.length == 2;
+            headerMap.put(headerPair[0], headerPair[1]);
+        }
+        return headerMap;
+    }
+}

--- a/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
@@ -36,7 +36,7 @@ public class EndpointCaller {
             response = new GetRequest(endpointToSend).send();
             break;
         case POST:
-            //to-do
+            response = new PostRequest(endpointToSend).send();
             break;
         case PUT:
             //to-do

--- a/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
@@ -25,7 +25,7 @@ public class PostRequest extends Request {
     }
 
     /**
-     * Executes the API call with a get request.
+     * Executes the API call with a post request.
      *
      * @return returns the response from the API call
      */

--- a/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
@@ -2,23 +2,26 @@ package seedu.us.among.logic.endpoint;
 
 import java.io.IOException;
 
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.Response;
 
 /**
- * Contains the logic for sending get requests.
+ * Contains the logic for sending post requests.
  */
-public class GetRequest extends Request {
+public class PostRequest extends Request {
+
+    private final Endpoint endpoint;
 
     /**
-     * Constructor for GetRequest.
+     * Constructor for PostRequest.
      *
      * @param endpoint endpoint to make API call on
      */
-    public GetRequest(Endpoint endpoint) {
+    public PostRequest(Endpoint endpoint) {
         super(endpoint.getMethod().getMethodType(), endpoint.getAddress().value);
+        this.endpoint = endpoint;
     }
 
     /**
@@ -28,7 +31,11 @@ public class GetRequest extends Request {
      */
     @Override
     public Response send() throws IOException {
-        HttpGet request = new HttpGet(this.getAddress());
+        HttpPost request = new HttpPost(this.getAddress());
+
+        request = (HttpPost) super.setHeaders(request, this.endpoint.getHeaders());
+        request = (HttpPost) super.setData(request, this.endpoint.getData());
+
         return super.execute(request);
     }
 }


### PR DESCRIPTION
Add support for POST request. While doing so, the following changes were made:
- Abstract the bulk of send request logic (including timing) from `GetRequest` into `Request` class
- Abstract setting of headers and data into `Request` class
- Add a HeaderUtil class to parse header information

With this PR, post request is integrated with the header and data field from endpoint as well. That is, a correctly added post request should now work.

Closes #167 