### PR TITLE
Fix: add headers to get request and trim headers properly

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
@@ -20,9 +20,12 @@ public class HeaderUtil {
         HashMap<String, String> headerMap = new HashMap<>();
         for (Header header : headerSet) {
             String headerString = header.toString();
+            //to-do update trimming once handling of headers is updated on add
+            //trim leading and trailing brackets and quotations
+            headerString = headerString.substring(2, headerString.length() - 2);
             String[] headerPair = headerString.split(":", 2);
             assert headerPair.length == 2;
-            headerMap.put(headerPair[0], headerPair[1]);
+            headerMap.put(headerPair[0].trim(), headerPair[1].trim());
         }
         return headerMap;
     }

--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -11,6 +11,7 @@ import seedu.us.among.model.endpoint.Response;
  * Contains the logic for sending get requests.
  */
 public class GetRequest extends Request {
+    private final Endpoint endpoint;
 
     /**
      * Constructor for GetRequest.
@@ -19,6 +20,7 @@ public class GetRequest extends Request {
      */
     public GetRequest(Endpoint endpoint) {
         super(endpoint.getMethod().getMethodType(), endpoint.getAddress().value);
+        this.endpoint = endpoint;
     }
 
     /**
@@ -29,6 +31,7 @@ public class GetRequest extends Request {
     @Override
     public Response send() throws IOException {
         HttpGet request = new HttpGet(this.getAddress());
+        request = (HttpGet) super.setHeaders(request, this.endpoint.getHeaders());
         return super.execute(request);
     }
 }


### PR DESCRIPTION
Remove leading/trailing brackets and quotations from headers (to be updated again once parsing is updated on add command).
Add setting of headers to get request.

Fixes #180 