### PR TITLE
Fix: add handling of exceptions when sending request

### DIFF
--- a/src/main/java/seedu/us/among/logic/Logic.java
+++ b/src/main/java/seedu/us/among/logic/Logic.java
@@ -6,6 +6,7 @@ import javafx.collections.ObservableList;
 import seedu.us.among.commons.core.GuiSettings;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 import seedu.us.among.model.Model;
 import seedu.us.among.model.ReadOnlyEndpointList;
@@ -22,7 +23,7 @@ public interface Logic {
      * @throws CommandException If an error occurs during command execution.
      * @throws ParseException If an error occurs during parsing.
      */
-    CommandResult execute(String commandText) throws CommandException, ParseException;
+    CommandResult execute(String commandText) throws CommandException, ParseException, RequestException;
 
     /**
      * Returns the EndpointList.

--- a/src/main/java/seedu/us/among/logic/LogicManager.java
+++ b/src/main/java/seedu/us/among/logic/LogicManager.java
@@ -10,6 +10,7 @@ import seedu.us.among.commons.core.LogsCenter;
 import seedu.us.among.logic.commands.Command;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.ImposterParser;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 import seedu.us.among.model.Model;
@@ -38,7 +39,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public CommandResult execute(String commandText) throws CommandException, ParseException {
+    public CommandResult execute(String commandText) throws CommandException, ParseException, RequestException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;

--- a/src/main/java/seedu/us/among/logic/commands/Command.java
+++ b/src/main/java/seedu/us/among/logic/commands/Command.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.commands;
 
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.Model;
 
 /**
@@ -15,6 +16,6 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model) throws CommandException;
+    public abstract CommandResult execute(Model model) throws CommandException, RequestException;
 
 }

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -27,6 +27,8 @@ import seedu.us.among.model.endpoint.header.Header;
  * Parent class of request sending classes. Contains the two compulsory fields method and address.
  */
 public abstract class Request {
+    private static final int timeout = 60;
+
     private final MethodType method;
     private final String address;
 
@@ -62,7 +64,6 @@ public abstract class Request {
      * @return http client to execute request
      */
     private CloseableHttpClient createHttpClient() {
-        int timeout = 60;
         RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(timeout * 1000)
                 .setConnectionRequestTimeout(timeout * 1000)

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -5,13 +5,14 @@ import java.util.HashMap;
 import java.util.Set;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
 import seedu.us.among.commons.util.HeaderUtil;
@@ -56,6 +57,20 @@ public abstract class Request {
     public abstract Response send() throws IOException;
 
     /**
+     * Creates a http client with timeout set to 60 seconds.
+     *
+     * @return http client to execute request
+     */
+    private CloseableHttpClient createHttpClient() {
+        int timeout = 60;
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(timeout * 1000)
+                .setConnectionRequestTimeout(timeout * 1000)
+                .setSocketTimeout(timeout * 1000).build();
+        return HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+    }
+
+    /**
      * Executes API call.
      *
      * @param request request to execute
@@ -63,7 +78,7 @@ public abstract class Request {
      */
     public Response execute(HttpUriRequest request) throws IOException {
         //solution adapted from https://mkyong.com/java/apache-httpclient-examples/
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = createHttpClient();
         CloseableHttpResponse response;
         String responseEntity = "";
         double responseTimeInSecond;

--- a/src/main/java/seedu/us/among/logic/endpoint/exceptions/RequestException.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/exceptions/RequestException.java
@@ -1,0 +1,12 @@
+package seedu.us.among.logic.endpoint.exceptions;
+
+import seedu.us.among.logic.endpoint.Request;
+
+/**
+ * Represents an error which occurs during execution of a {@link Request}.
+ */
+public class RequestException extends Exception {
+    public RequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -8,6 +8,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.Region;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
 /**
@@ -44,7 +45,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-        } catch (CommandException | ParseException e) {
+        } catch (CommandException | ParseException | RequestException e) {
             setStyleToIndicateCommandFailure();
         } finally {
             commandTextField.setDisable(false);
@@ -125,7 +126,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see seedu.us.among.logic.Logic#execute(String)
          */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
+        CommandResult execute(String commandText) throws CommandException, ParseException, RequestException;
     }
 
 }

--- a/src/main/java/seedu/us/among/ui/MainWindow.java
+++ b/src/main/java/seedu/us/among/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.us.among.commons.core.LogsCenter;
 import seedu.us.among.logic.Logic;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
 /**
@@ -177,7 +178,7 @@ public class MainWindow extends UiPart<Stage> {
      *
      * @see Logic#execute(String)
      */
-    private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
+    private CommandResult executeCommand(String commandText) throws CommandException, ParseException, RequestException {
         resultDisplay.setFeedbackToUser("");
         resultDisplay.getLoadingSpinnerPlaceholder().setVisible(true);
         try {
@@ -199,7 +200,7 @@ public class MainWindow extends UiPart<Stage> {
             }
 
             return commandResult;
-        } catch (CommandException | ParseException e) {
+        } catch (CommandException | ParseException | RequestException e) {
             //stop loading spinner (if any)
             resultDisplay.getLoadingSpinnerPlaceholder().setVisible(false);
 

--- a/src/test/java/seedu/us/among/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/us/among/logic/LogicManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.ListCommand;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 import seedu.us.among.model.Model;
 import seedu.us.among.model.ModelManager;
@@ -101,7 +102,7 @@ public class LogicManagerTest {
      * @see #assertCommandFailure(String, Class, String, Model)
      */
     private void assertCommandSuccess(String inputCommand, String expectedMessage, Model expectedModel)
-            throws CommandException, ParseException {
+            throws CommandException, ParseException, RequestException {
         CommandResult result = logic.execute(inputCommand);
         assertEquals(expectedMessage, result.getFeedbackToUser());
         assertEquals(expectedModel, model);

--- a/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import seedu.us.among.commons.core.index.Index;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.EndpointList;
 import seedu.us.among.model.Model;
 import seedu.us.among.model.endpoint.Endpoint;
@@ -68,7 +69,7 @@ public class CommandTestUtil {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
-        } catch (CommandException ce) {
+        } catch (CommandException | RequestException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }
     }


### PR DESCRIPTION
In addressing the uncaught request exceptions, the following changes have been made:
- Add `RequestException` class to deal with 4 different exceptions thrown when sending a request.
- Timeout implemented for all requests, currently set to 1 minute.

Fixes #187 