### PR TITLE
Fix: add proper catch for html response

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -41,6 +41,8 @@ public class SendCommand extends Command {
             + " that your data is added in the correct JSON format.";
     public static final String MESSAGE_CONNECTION_ERROR = "The request was not performed successfully."
             + " Check your internet connection and endpoint URL.";
+    public static final String MESSAGE_GENERAL_ERROR = "The request was not performed successfully."
+            + " Check that your endpoint fields are correct.";
 
     private final Index index;
 
@@ -72,7 +74,7 @@ public class SendCommand extends Command {
         } catch (JsonParseException e) {
             throw new RequestException(MESSAGE_INVALID_JSON);
         } catch (IOException e) {
-            throw new RequestException("An error e.getMessage()");
+            throw new RequestException(MESSAGE_GENERAL_ERROR);
         }
 
         Endpoint endpointWithResponse = createEndpointWithResponse(endpointToSend, response);

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -82,28 +82,25 @@ public abstract class Request {
         CloseableHttpClient httpClient = createHttpClient();
         CloseableHttpResponse response;
         String responseEntity = "";
+
         double responseTimeInSecond;
-        try {
-            long start = System.nanoTime();
-            response = httpClient.execute(request);
-            long end = System.nanoTime();
-            long duration = end - start;
-            responseTimeInSecond = (double) duration / 1_000_000_000;
+        long start = System.nanoTime();
+        response = httpClient.execute(request);
+        long end = System.nanoTime();
+        long duration = end - start;
+        responseTimeInSecond = (double) duration / 1_000_000_000;
 
-            try {
-                HttpEntity entity = response.getEntity();
-                if (entity != null) {
-                    //return data as string
-                    responseEntity = EntityUtils.toString(entity);
-                    responseEntity = JsonUtil.toPrettyPrintJsonString(responseEntity);
-                }
-
-            } finally {
-                response.close();
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            //return data as string
+            responseEntity = EntityUtils.toString(entity);
+            if (entity.getContentType().getValue().equals(ContentType.APPLICATION_JSON.toString())) {
+                responseEntity = JsonUtil.toPrettyPrintJsonString(responseEntity);
             }
-        } finally {
-            httpClient.close();
         }
+
+        response.close();
+        httpClient.close();
 
         return new Response(response.getProtocolVersion().toString(),
                 String.valueOf(response.getStatusLine().getStatusCode()),

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -94,7 +94,7 @@ public abstract class Request {
         if (entity != null) {
             //return data as string
             responseEntity = EntityUtils.toString(entity);
-            if (entity.getContentType().getValue().equals(ContentType.APPLICATION_JSON.toString())) {
+            if (entity.getContentType().getValue().toLowerCase().contains("application/json")) {
                 responseEntity = JsonUtil.toPrettyPrintJsonString(responseEntity);
             }
         }


### PR DESCRIPTION
HTML responses are currently caught as other exceptions (e.g. json parse exception). This PR does the following:
- Show HTML responses correctly
- Minor refactor to Request#execute code for readability

Fixes #191 