### PR TITLE
Fix: add a check when parsing headers and catch invalid headers

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
@@ -3,12 +3,15 @@ package seedu.us.among.commons.util;
 import java.util.HashMap;
 import java.util.Set;
 
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.header.Header;
 
 /**
  * Helper function for retrieving key-value from header strings.
  */
 public class HeaderUtil {
+    public static final String MESSAGE_INVALID_HEADER_FORMAT = "There was an error parsing the header."
+            + " Please check that your header specified is in the correct format.";
 
     /**
      * Converts hashset of headers to a hashmap of header key-value pair.
@@ -16,7 +19,7 @@ public class HeaderUtil {
      * @param headerSet set of headers from endpoint
      * @return hashmap of header key-value pair
      */
-    public static HashMap<String, String> parseHeaders(Set<Header> headerSet) {
+    public static HashMap<String, String> parseHeaders(Set<Header> headerSet) throws RequestException {
         HashMap<String, String> headerMap = new HashMap<>();
         for (Header header : headerSet) {
             String headerString = header.toString();
@@ -24,7 +27,9 @@ public class HeaderUtil {
             //trim leading and trailing brackets and quotations
             headerString = headerString.substring(2, headerString.length() - 2);
             String[] headerPair = headerString.split(":", 2);
-            assert headerPair.length == 2;
+            if (headerPair.length != 2) {
+                throw new RequestException(MESSAGE_INVALID_HEADER_FORMAT);
+            }
             headerMap.put(headerPair[0].trim(), headerPair[1].trim());
         }
         return headerMap;

--- a/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/EndpointCaller.java
@@ -2,6 +2,7 @@ package seedu.us.among.logic.endpoint;
 
 import java.io.IOException;
 
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.MethodType;
 import seedu.us.among.model.endpoint.Response;
@@ -26,7 +27,7 @@ public class EndpointCaller {
      *
      * @return response of API call
      */
-    public Response callEndpoint() throws IOException {
+    public Response callEndpoint() throws IOException, RequestException {
 
         Response response = new Response();
         MethodType requestMethod = this.endpointToSend.getMethod().getMethodType();

--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.apache.http.client.methods.HttpGet;
 
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.Response;
 
@@ -29,7 +30,7 @@ public class GetRequest extends Request {
      * @return returns the response from the API call
      */
     @Override
-    public Response send() throws IOException {
+    public Response send() throws IOException, RequestException {
         HttpGet request = new HttpGet(this.getAddress());
         request = (HttpGet) super.setHeaders(request, this.endpoint.getHeaders());
         return super.execute(request);

--- a/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.apache.http.client.methods.HttpPost;
 
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.Response;
 
@@ -30,7 +31,7 @@ public class PostRequest extends Request {
      * @return returns the response from the API call
      */
     @Override
-    public Response send() throws IOException {
+    public Response send() throws IOException, RequestException {
         HttpPost request = new HttpPost(this.getAddress());
 
         request = (HttpPost) super.setHeaders(request, this.endpoint.getHeaders());

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -18,6 +18,7 @@ import org.apache.http.util.EntityUtils;
 import seedu.us.among.commons.util.HeaderUtil;
 import seedu.us.among.commons.util.JsonUtil;
 import seedu.us.among.commons.util.StringUtil;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Data;
 import seedu.us.among.model.endpoint.MethodType;
 import seedu.us.among.model.endpoint.Response;
@@ -56,7 +57,7 @@ public abstract class Request {
      *
      * @return returns the response from the API call
      */
-    public abstract Response send() throws IOException;
+    public abstract Response send() throws IOException, RequestException;
 
     /**
      * Creates a http client with timeout set to 60 seconds.
@@ -117,7 +118,7 @@ public abstract class Request {
      * @param headerSet set of headers from endpoint
      * @return request with headers set
      */
-    public HttpUriRequest setHeaders(HttpUriRequest request, Set<Header> headerSet) {
+    public HttpUriRequest setHeaders(HttpUriRequest request, Set<Header> headerSet) throws RequestException {
         HashMap<String, String> headerMap = HeaderUtil.parseHeaders(headerSet);
         for (HashMap.Entry<String, String> headerPair : headerMap.entrySet()) {
             request.addHeader(headerPair.getKey(), headerPair.getValue());


### PR DESCRIPTION
Add a check when parsing header to catch invalid headers and throw a `RequestException`.

Fixes #198 