### PR TITLE
Model and Commands: Wrapped things up and fixed many bugs. 

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/HeaderUtil.java
@@ -20,9 +20,6 @@ public class HeaderUtil {
         HashMap<String, String> headerMap = new HashMap<>();
         for (Header header : headerSet) {
             String headerString = header.toString();
-            //to-do update trimming once handling of headers is updated on add
-            //trim leading and trailing brackets and quotations
-            headerString = headerString.substring(2, headerString.length() - 2);
             String[] headerPair = headerString.split(":", 2);
             assert headerPair.length == 2;
             headerMap.put(headerPair[0].trim(), headerPair[1].trim());

--- a/src/main/java/seedu/us/among/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/AddCommand.java
@@ -18,26 +18,28 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_API_EXAMPLE_1 = "1.\n"
+    public static final String MESSAGE_API_EXAMPLE_1 = "1. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + " get "
-            + PREFIX_ADDRESS + " https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=2 "
-            + PREFIX_DATA + " {somedata} "
-            + PREFIX_TAG + " cat "
-            + PREFIX_TAG + " fact\n";
+            + PREFIX_METHOD + "get "
+            + PREFIX_ADDRESS + "http://localhost:3000/ "
+            + PREFIX_DATA + "{some data} "
+            + PREFIX_HEADER + "\"key: value\" "
+            + PREFIX_HEADER + "\"key: value\" "
+            + PREFIX_TAG + "local "
+            + PREFIX_TAG + "data\n";
 
-    public static final String MESSAGE_API_EXAMPLE_2 = "2.\n"
+    public static final String MESSAGE_API_EXAMPLE_2 = "2. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + " get "
-            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature "
-            + PREFIX_TAG + " singapore ";
+            + PREFIX_METHOD + "get "
+            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature ";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an API endpoint to the API endpoint list.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds an API endpoint to the API endpoint list.\n"
             + "Parameters: "
             + PREFIX_METHOD + " METHOD "
             + PREFIX_ADDRESS + " ADDRESS "
             + "[" + PREFIX_DATA + " DATA] "
-            + "[" + PREFIX_HEADER + " HEADER] "
+            + "[" + PREFIX_HEADER + " HEADER]... "
             + "[" + PREFIX_TAG + " TAG]...\n"
             + "Examples:\n"
             + MESSAGE_API_EXAMPLE_1

--- a/src/main/java/seedu/us/among/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/AddCommandParser.java
@@ -30,7 +30,9 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_METHOD,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_METHOD,
                 PREFIX_ADDRESS,
                 PREFIX_DATA,
                 PREFIX_HEADER,

--- a/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
@@ -7,10 +7,10 @@ package seedu.us.among.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_METHOD = new Prefix("-x");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("-u");
-    public static final Prefix PREFIX_TAG = new Prefix("-t");
-    public static final Prefix PREFIX_HEADER = new Prefix("-h");
-    public static final Prefix PREFIX_DATA = new Prefix("-d");
+    public static final Prefix PREFIX_METHOD = new Prefix("-x ");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-u ");
+    public static final Prefix PREFIX_TAG = new Prefix("-t ");
+    public static final Prefix PREFIX_HEADER = new Prefix("-h ");
+    public static final Prefix PREFIX_DATA = new Prefix("-d ");
 
 }

--- a/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
@@ -36,7 +36,7 @@ public class ImposterParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim().toLowerCase());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/us/among/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/us/among/logic/parser/ParserUtil.java
@@ -92,7 +92,7 @@ public class ParserUtil {
         requireNonNull(header);
         String trimmedHeader = header.trim();
         if (!Header.isValidHeaderName(trimmedHeader)) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Header.MESSAGE_CONSTRAINTS);
         }
         return new Header(trimmedHeader);
     }

--- a/src/main/java/seedu/us/among/model/endpoint/Data.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Data.java
@@ -51,13 +51,13 @@ public class Data {
         String headerString = test.strip().toString();
         String[] headerPair = headerString.split(":", 2);
         //Checks if there is a ":" in the data entered.
-        if (headerPair.length != 2) { 
+        if (headerPair.length != 2) {
             return false;
         }
         //Checks if header is enclosed with { }
         if (headerString.startsWith("{") && headerString.endsWith("}")) {
             return test.matches(VALIDATION_REGEX);
-        } else { 
+        } else {
             return false;
         }
     }

--- a/src/main/java/seedu/us/among/model/endpoint/Data.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Data.java
@@ -8,8 +8,8 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidData(String)}
  */
 public class Data {
-
-    public static final String MESSAGE_CONSTRAINTS = "Data must be in a json string";
+    //to-do Jun Xiong Tan Jin force data to take in only json files
+    public static final String MESSAGE_CONSTRAINTS = "Data must be in a {\"key\": \"value\"} format.";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -48,7 +48,18 @@ public class Data {
      * Returns true if a given string is a valid Data.
      */
     public static boolean isValidData(String test) {
-        return test.matches(VALIDATION_REGEX);
+        String headerString = test.strip().toString();
+        String[] headerPair = headerString.split(":", 2);
+        //Checks if there is a ":" in the data entered.
+        if (headerPair.length != 2) { 
+            return false;
+        }
+        //Checks if header is enclosed with { }
+        if (headerString.startsWith("{") && headerString.endsWith("}")) {
+            return test.matches(VALIDATION_REGEX);
+        } else { 
+            return false;
+        }
     }
 
     public static boolean isEmptyData(String test) {

--- a/src/main/java/seedu/us/among/model/endpoint/Endpoint.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Endpoint.java
@@ -122,19 +122,10 @@ public class Endpoint {
             return true;
         }
 
-        //expanded this for more clarity
         if (otherEndpoint == null) {
             return false;
         } else {
-            if (otherEndpoint.getMethod().equals(getMethod())
-                    && otherEndpoint.getAddress().equals(getAddress())
-                    && otherEndpoint.getData().equals(getData())
-                    && otherEndpoint.getHeaders().equals(getHeaders())
-                    && otherEndpoint.getTags().equals(getTags())) {
-                return true;
-            } else {
-                return false;
-            }
+            return this.equals(otherEndpoint);
         }
     }
 

--- a/src/main/java/seedu/us/among/model/endpoint/header/Header.java
+++ b/src/main/java/seedu/us/among/model/endpoint/header/Header.java
@@ -53,7 +53,7 @@ public class Header {
      * Format state as text for viewing.
      */
     public String toString() {
-        return headerName;
+        return headerName.substring(1, headerName.length() - 1);
     }
 
 }

--- a/src/main/java/seedu/us/among/model/endpoint/header/Header.java
+++ b/src/main/java/seedu/us/among/model/endpoint/header/Header.java
@@ -8,12 +8,8 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; name is valid as declared in {@link #isValidHeaderName(String)}
  */
 public class Header {
-    /**
-     * to-do
-     * THIS WHOLE CLASS IS A TO-DO I JUST COPY PASTED TAGS
-     */
 
-    public static final String MESSAGE_CONSTRAINTS = "Header names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Headers should be enclosed with a \" example \"";
     public static final String VALIDATION_REGEX = ".*";
 
     public final String headerName;
@@ -25,15 +21,20 @@ public class Header {
      */
     public Header(String headerName) {
         requireNonNull(headerName);
-        checkArgument(isValidHeaderName(headerName), MESSAGE_CONSTRAINTS);
-        this.headerName = headerName;
+        checkArgument(isValidHeaderName(headerName), Header.MESSAGE_CONSTRAINTS);
+        this.headerName = headerName.substring(1, headerName.length() - 1);
     }
 
     /**
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidHeaderName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        String temp = test.strip();
+        if (temp.startsWith("\"") && temp.endsWith("\"")) {
+            return test.matches(VALIDATION_REGEX);
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -52,7 +53,7 @@ public class Header {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + headerName + ']';
+        return headerName;
     }
 
 }

--- a/src/main/java/seedu/us/among/model/endpoint/header/Header.java
+++ b/src/main/java/seedu/us/among/model/endpoint/header/Header.java
@@ -9,7 +9,7 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
  */
 public class Header {
 
-    public static final String MESSAGE_CONSTRAINTS = "Headers should be enclosed with a \" example \"";
+    public static final String MESSAGE_CONSTRAINTS = "Headers should be enclosed with a \" \"";
     public static final String VALIDATION_REGEX = ".*";
 
     public final String headerName;
@@ -22,7 +22,7 @@ public class Header {
     public Header(String headerName) {
         requireNonNull(headerName);
         checkArgument(isValidHeaderName(headerName), Header.MESSAGE_CONSTRAINTS);
-        this.headerName = headerName.substring(1, headerName.length() - 1);
+        this.headerName = headerName;
     }
 
     /**

--- a/src/main/java/seedu/us/among/model/endpoint/header/Header.java
+++ b/src/main/java/seedu/us/among/model/endpoint/header/Header.java
@@ -9,7 +9,7 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
  */
 public class Header {
 
-    public static final String MESSAGE_CONSTRAINTS = "Headers should be enclosed with a \" \"";
+    public static final String MESSAGE_CONSTRAINTS = "Headers should be in the \"key: value\" format.";
     public static final String VALIDATION_REGEX = ".*";
 
     public final String headerName;
@@ -29,8 +29,14 @@ public class Header {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidHeaderName(String test) {
-        String temp = test.strip();
-        if (temp.startsWith("\"") && temp.endsWith("\"")) {
+        String headerString = test.strip().toString();
+        String[] headerPair = headerString.split(":", 2);
+        //Checks if there is a ":" in the data entered.
+        if (headerPair.length != 2) { 
+            return false;
+        }
+        //Checks if header is enclosed with ""
+        if (headerString.startsWith("\"") && headerString.endsWith("\"")) {
             return test.matches(VALIDATION_REGEX);
         } else {
             return false;

--- a/src/main/java/seedu/us/among/model/endpoint/header/Header.java
+++ b/src/main/java/seedu/us/among/model/endpoint/header/Header.java
@@ -32,7 +32,7 @@ public class Header {
         String headerString = test.strip().toString();
         String[] headerPair = headerString.split(":", 2);
         //Checks if there is a ":" in the data entered.
-        if (headerPair.length != 2) { 
+        if (headerPair.length != 2) {
             return false;
         }
         //Checks if header is enclosed with ""

--- a/src/main/java/seedu/us/among/model/tag/Tag.java
+++ b/src/main/java/seedu/us/among/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric 123";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;

--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -45,7 +45,8 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-        } catch (CommandException | ParseException | RequestException e) {
+            //to-do remove illegal arg exception Jun Xiong and Tan Jin
+        } catch (CommandException | ParseException | RequestException | IllegalArgumentException e) {
             setStyleToIndicateCommandFailure();
         } finally {
             commandTextField.setDisable(false);

--- a/src/main/java/seedu/us/among/ui/EndpointCard.java
+++ b/src/main/java/seedu/us/among/ui/EndpointCard.java
@@ -53,8 +53,8 @@ public class EndpointCard extends UiPart<Region> {
         name.setText(endpoint.getMethod().methodName);
         address.setText(endpoint.getAddress().value);
         data.setText(endpoint.getData().value);
-        endpoint.getHeaders().stream().sorted(Comparator.comparing(header -> header.headerName))
-                .forEach(header -> headers.getChildren().add(new Label(header.headerName)));
+        endpoint.getHeaders().stream().sorted(Comparator.comparing(header -> header.toString()))
+                .forEach(header -> headers.getChildren().add(new Label(header.toString())));
         endpoint.getTags().stream().sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }

--- a/src/test/java/seedu/us/among/testutil/TypicalEndpoints.java
+++ b/src/test/java/seedu/us/among/testutil/TypicalEndpoints.java
@@ -22,64 +22,64 @@ public class TypicalEndpoints {
 
     public static final Endpoint GET = new EndpointBuilder().withMethod("GET")
             .withAddress("https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=2")
-            .withData("{testingdata}")
+            .withData("{key: value}")
             .withTags("cat")
-            .withHeaders("headers")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint POST = new EndpointBuilder().withMethod("POST")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}").withTags("cat", "fact")
-            .withHeaders("headers")
+            .withData("{key: value}").withTags("cat", "fact")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint PUT = new EndpointBuilder().withMethod("PUT")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint DELETE = new EndpointBuilder().withMethod("DELETE")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
+            .withData("{key: value}")
             .withTags("Fact")
-            .withHeaders("headers")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint HEAD = new EndpointBuilder()
             .withMethod("HEAD")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint OPTIONS = new EndpointBuilder()
             .withMethod("OPTIONS")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint PATCH = new EndpointBuilder()
             .withMethod("PATCH")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
 
     // Manually added //to-do Fixe these test cases
     public static final Endpoint GET1 = new EndpointBuilder()
             .withMethod("GET")
             .withAddress("https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=2")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
     public static final Endpoint GET2 = new EndpointBuilder()
             .withMethod("GET")
             .withAddress("https://cat-fact.herokuapp.com/facts")
-            .withData("{testingdata}")
-            .withHeaders("headers")
+            .withData("{key: value}")
+            .withHeaders("\"key: value\"")
             .build();
 
     // Manually added - Endpoint's details found in {@code CommandTestUtil}
     public static final Endpoint GET3 = new EndpointBuilder().withMethod(VALID_METHOD_GET)
-            .withAddress(VALID_ADDRESS_RANDOM).withData("{testingdata}").withTags(VALID_TAG_COOL).build();
+            .withAddress(VALID_ADDRESS_RANDOM).withData("{key: value}").withTags(VALID_TAG_COOL).build();
     public static final Endpoint POST1 = new EndpointBuilder().withMethod(VALID_METHOD_POST)
-            .withAddress(VALID_ADDRESS_FACT).withData("{testingdata}").withTags(VALID_TAG_CAT, VALID_TAG_COOL).build();
+            .withAddress(VALID_ADDRESS_FACT).withData("{key: value}").withTags(VALID_TAG_CAT, VALID_TAG_COOL).build();
 
     public static final String KEYWORD_MATCHING_GET = "GET"; // A keyword that matches MEIER
 


### PR DESCRIPTION
Fixes #155 
Fixes #157 

Updated Imposter Parser, can take in command in any letter case now: e.g. ADD and aDD are all accepted. 

Updated CLISyntax, users must now put a space after their command identifier. 

Updated Add command, changed error message and cleaned things up 

Updated Header, must enclose the string in `"key: value"` format.

Updated Data, must enclose string in {key: value} format. //to-do let this only take in json format.

As of now, the only commands not done is `find` and `help` commands. 