### PR TITLE
Add RunCommand ability

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -1,0 +1,132 @@
+package seedu.us.among.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_DATA;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_HEADER;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_METHOD;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Set;
+
+import org.apache.http.client.ClientProtocolException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.EndpointCaller;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
+import seedu.us.among.model.Model;
+import seedu.us.among.model.endpoint.Address;
+import seedu.us.among.model.endpoint.Data;
+import seedu.us.among.model.endpoint.Endpoint;
+import seedu.us.among.model.endpoint.Method;
+import seedu.us.among.model.endpoint.Response;
+import seedu.us.among.model.endpoint.header.Header;
+import seedu.us.among.model.tag.Tag;
+
+public class RunCommand extends Command {
+
+    public static final String COMMAND_WORD = "run";
+
+    public static final String MESSAGE_API_EXAMPLE_1 = "1. "
+            + COMMAND_WORD + " "
+            + PREFIX_METHOD + "get "
+            + PREFIX_ADDRESS + "http://localhost:3000/ "
+            + PREFIX_DATA + "{\"some\": \"data\"} "
+            + PREFIX_HEADER + "\"key: value\" "
+            + PREFIX_HEADER + "\"key: value\"\n";
+
+    public static final String MESSAGE_API_EXAMPLE_2 = "2. "
+            + COMMAND_WORD + " "
+            + PREFIX_METHOD + "get "
+            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature ";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Runs an API request without saving it to the API endpoint list.\n"
+            + "Parameters: "
+            + PREFIX_METHOD + " METHOD "
+            + PREFIX_ADDRESS + " ADDRESS "
+            + "[" + PREFIX_DATA + " DATA] "
+            + "[" + PREFIX_HEADER + " HEADER]...\n"
+            + "Examples:\n"
+            + MESSAGE_API_EXAMPLE_1
+            + MESSAGE_API_EXAMPLE_2;
+
+    public static final String MESSAGE_INVALID_JSON = "The request was not performed successfully. Check"
+            + " that your data is added in the correct JSON format.";
+    public static final String MESSAGE_CONNECTION_ERROR = "The request was not performed successfully."
+            + " Check your internet connection and endpoint URL.";
+    public static final String MESSAGE_GENERAL_ERROR = "The request was not performed successfully."
+            + " Check that your endpoint fields are correct.";
+    private final Endpoint toRun;
+
+    /**
+     * Creates an RunCommand to run the specified {@code Endpoint}
+     */
+    public RunCommand(Endpoint endpoint) {
+        requireNonNull(endpoint);
+        toRun = endpoint;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException, RequestException {
+        requireNonNull(model);
+
+        EndpointCaller epc = new EndpointCaller(toRun);
+        Response response;
+        try {
+            response = epc.callEndpoint();
+        } catch (UnknownHostException | ClientProtocolException | SocketTimeoutException e) {
+            throw new RequestException(MESSAGE_CONNECTION_ERROR);
+        } catch (JsonParseException e) {
+            throw new RequestException(MESSAGE_INVALID_JSON);
+        } catch (IOException e) {
+            throw new RequestException(MESSAGE_GENERAL_ERROR);
+        }
+
+        Endpoint endpointWithResponse = createEndpointWithResponse(toRun, response);
+
+        return new CommandResult(endpointWithResponse.getResponse().getResponseEntity(),
+                endpointWithResponse,
+                false,
+                false,
+                true);
+    }
+
+    /**
+     * Creates and returns a {@code Endpoint} with the details of {@code endpointToSend}
+     * edited with {@code editEndpointDescriptor}.
+     */
+    private static Endpoint createEndpointWithResponse(Endpoint endpointToSend, Response endpointResponse) {
+        assert endpointToSend != null;
+
+        Method method = endpointToSend.getMethod();
+        Address address = endpointToSend.getAddress();
+        Data data = endpointToSend.getData();
+        Set<Header> headers = endpointToSend.getHeaders();
+        Set<Tag> tags = endpointToSend.getTags();
+
+        return new Endpoint(method, address, data, headers, tags, endpointResponse);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RunCommand)) {
+            return false;
+        }
+
+        // endpoint check
+        RunCommand otherRunCommand = (RunCommand) other;
+        return this.toRun.equals(otherRunCommand.toRun);
+    }
+
+}

--- a/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
@@ -15,6 +15,7 @@ import seedu.us.among.logic.commands.FindCommand;
 import seedu.us.among.logic.commands.HelpCommand;
 import seedu.us.among.logic.commands.ListCommand;
 import seedu.us.among.logic.commands.RemoveCommand;
+import seedu.us.among.logic.commands.RunCommand;
 import seedu.us.among.logic.commands.SendCommand;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
@@ -71,6 +72,9 @@ public class ImposterParser {
 
         case SendCommand.COMMAND_WORD:
             return new SendCommandParser().parse(arguments);
+
+        case RunCommand.COMMAND_WORD:
+            return new RunCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/us/among/logic/parser/RunCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/RunCommandParser.java
@@ -1,0 +1,68 @@
+package seedu.us.among.logic.parser;
+
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_DATA;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_HEADER;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_METHOD;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.us.among.logic.commands.RunCommand;
+import seedu.us.among.logic.parser.exceptions.ParseException;
+import seedu.us.among.model.endpoint.Address;
+import seedu.us.among.model.endpoint.Data;
+import seedu.us.among.model.endpoint.Endpoint;
+import seedu.us.among.model.endpoint.Method;
+import seedu.us.among.model.endpoint.header.Header;
+import seedu.us.among.model.tag.Tag;
+
+public class RunCommandParser implements Parser<RunCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the RunCommand
+     * and returns a RunCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public RunCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_METHOD,
+                PREFIX_ADDRESS,
+                PREFIX_DATA,
+                PREFIX_HEADER,
+                PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_METHOD, PREFIX_ADDRESS)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RunCommand.MESSAGE_USAGE));
+        }
+
+        Method method = ParserUtil.parseMethod(argMultimap.getValue(PREFIX_METHOD).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Set<Header> headerList = ParserUtil.parseHeaders(argMultimap.getAllValues(PREFIX_HEADER));
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        Endpoint endpoint;
+
+        if (argMultimap.getValue(PREFIX_DATA).isEmpty()) {
+            endpoint = new Endpoint(method, address, headerList, tagList);
+        } else {
+            Data data = ParserUtil.parseData(argMultimap.getValue(PREFIX_DATA).orElse(""));
+            endpoint = new Endpoint(method, address, data, headerList, tagList);
+        }
+
+        return new RunCommand(endpoint);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+
+}


### PR DESCRIPTION
Without RunCommand, users have to rely on saving API endpoints then
running it by invoking the send command.

Let's add a run command that allows users to run API requests without
saving them.

This will improve user experience in terms of quickly testing out an
API endpoint.

More refactoring to the code is needed but due to big PRs soon to be
made by TJ and JX, I shall not make any potential breaking changes in
this PR in terms of code organisation.

Fixes #152 
