### PR TITLE
Feat: add keyboard shortcut for user to cancel request

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -3,11 +3,14 @@ package seedu.us.among.logic.commands;
 import static seedu.us.among.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Set;
+import javax.net.ssl.SSLException;
 
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.ClientProtocolException;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -41,6 +44,7 @@ public class SendCommand extends Command {
             + " that your data is added in the correct JSON format.";
     public static final String MESSAGE_CONNECTION_ERROR = "The request was not performed successfully."
             + " Check your internet connection and endpoint URL.";
+    public static final String MESSAGE_CALL_CANCELLED = "The request has been cancelled.";
     public static final String MESSAGE_GENERAL_ERROR = "The request was not performed successfully."
             + " Check that your endpoint fields are correct.";
 
@@ -73,6 +77,8 @@ public class SendCommand extends Command {
             throw new RequestException(MESSAGE_CONNECTION_ERROR);
         } catch (JsonParseException e) {
             throw new RequestException(MESSAGE_INVALID_JSON);
+        } catch (IllegalStateException | SSLException | NoHttpResponseException | SocketException e) {
+            throw new RequestException(MESSAGE_CALL_CANCELLED);
         } catch (IOException e) {
             throw new RequestException(MESSAGE_GENERAL_ERROR);
         }

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -13,6 +13,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 
 import seedu.us.among.commons.util.HeaderUtil;
@@ -28,6 +29,7 @@ import seedu.us.among.model.endpoint.header.Header;
  * Parent class of request sending classes. Contains the two compulsory fields method and address.
  */
 public abstract class Request {
+    private static CloseableHttpClient httpclient = HttpClients.createDefault();
     private static final int timeout = 60;
 
     private final MethodType method;
@@ -50,6 +52,10 @@ public abstract class Request {
 
     public String getAddress() {
         return this.address;
+    }
+
+    public static CloseableHttpClient getHttpclient() {
+        return httpclient;
     }
 
     /**
@@ -81,6 +87,7 @@ public abstract class Request {
     public Response execute(HttpUriRequest request) throws IOException {
         //solution adapted from https://mkyong.com/java/apache-httpclient-examples/
         CloseableHttpClient httpClient = createHttpClient();
+        Request.httpclient = httpClient;
         CloseableHttpResponse response;
         String responseEntity = "";
 

--- a/src/main/java/seedu/us/among/ui/MainWindow.java
+++ b/src/main/java/seedu/us/among/ui/MainWindow.java
@@ -1,12 +1,16 @@
 package seedu.us.among.ui;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -16,6 +20,7 @@ import seedu.us.among.commons.core.LogsCenter;
 import seedu.us.among.logic.Logic;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.Request;
 import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
@@ -36,6 +41,9 @@ public class MainWindow extends UiPart<Stage> {
     private EndpointListPanel endpointListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+
+    // Handle ctrl+c event for cancelling API calls
+    private EventHandler<KeyEvent> keyEventHandler;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -68,6 +76,8 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        initialiseKeyEventHandler();
     }
 
     public Stage getPrimaryStage() {
@@ -174,6 +184,45 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Closes httpClient when ctrl + c is pressed.
+     *
+     * @param event key event for pressed keys
+     */
+    public void closeHttpClient(KeyEvent event) throws IOException {
+        KeyCombination kc = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
+        if (kc.match(event)) {
+            Request.getHttpclient().close();
+        }
+    }
+
+    /**
+     * Initialises key handler to be method for handling ctrl + c input.
+     */
+    public void initialiseKeyEventHandler() {
+        this.keyEventHandler = e -> {
+            try {
+                closeHttpClient(e);
+            } catch (IOException ioException) {
+                logger.info("Unable to stop request: " + ioException.getMessage());
+            }
+        };
+    }
+
+    /**
+     * Sets the key event handler to look out for key input of ctrl + c from user.
+     */
+    public void setKeyEventHandler() {
+        primaryStage.addEventHandler(KeyEvent.KEY_PRESSED, this.keyEventHandler);
+    }
+
+    /**
+     * Unsets the key event handler that looks out for key input of ctrl + c from user.
+     */
+    public void unsetKeyEventHandler() {
+        primaryStage.addEventHandler(KeyEvent.KEY_PRESSED, this.keyEventHandler);
+    }
+
+    /**
      * Executes the command and returns the result.
      *
      * @see Logic#execute(String)
@@ -181,8 +230,10 @@ public class MainWindow extends UiPart<Stage> {
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException, RequestException {
         resultDisplay.setFeedbackToUser("");
         resultDisplay.getLoadingSpinnerPlaceholder().setVisible(true);
+        setKeyEventHandler();
         try {
             CommandResult commandResult = logic.execute(commandText);
+            unsetKeyEventHandler();
             resultDisplay.getLoadingSpinnerPlaceholder().setVisible(false);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             if (commandResult.isApiResponse()) {
@@ -201,6 +252,7 @@ public class MainWindow extends UiPart<Stage> {
 
             return commandResult;
         } catch (CommandException | ParseException | RequestException e) {
+            unsetKeyEventHandler();
             //stop loading spinner (if any)
             resultDisplay.getLoadingSpinnerPlaceholder().setVisible(false);
 
@@ -210,6 +262,8 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Invalid command: " + commandText);
             resultDisplay.setFeedbackToUser(e.getMessage());
             throw e;
+        } finally {
+            System.out.println(Thread.activeCount());
         }
     }
 }


### PR DESCRIPTION
Add a keyboard shortcut for users to cancel a request. The code has been trimmed down a lot and was not as complicated as I initially thought it would be. The changes are as such:
- `MainWindow` now looks out for a `ctrl + c` keyboard event in the time period when a player is making an API call.
- `Request` httpclient attribute is directly accessible from the keyboard event to close it, throwing an exception that is caught within `SendCommand`. @tlylt This should affect `RunCommand` as well, I have yet to update that portion of the code but you may be interested to take a look.
- The threads are automatically killed upon the interrupt (at least based on current observations).

Resolves #141 
Resolves #188 