### PR TITLE
Refactor: Request related code

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/AddCommand.java
@@ -22,7 +22,7 @@ public class AddCommand extends Command {
             + COMMAND_WORD + " "
             + PREFIX_METHOD + "get "
             + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{some: data} "
+            + PREFIX_DATA + "{\"some\": \"data\"} "
             + PREFIX_HEADER + "\"key: value\" "
             + PREFIX_HEADER + "\"key: value\" "
             + PREFIX_TAG + "local "

--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -95,8 +95,8 @@ public class SendCommand extends Command {
     }
 
     /**
-     * Creates and returns a {@code Endpoint} with the details of {@code endpointToEdit}
-     * edited with {@code editEndpointDescriptor}.
+     * Creates and returns a {@code Endpoint} with the details of {@code endpointToSend}
+     * edited with {@code endpointResponse}.
      */
     private static Endpoint createEndpointWithResponse(Endpoint endpointToSend, Response endpointResponse) {
         assert endpointToSend != null;

--- a/src/main/java/seedu/us/among/logic/endpoint/DeleteRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/DeleteRequest.java
@@ -12,7 +12,6 @@ import seedu.us.among.model.endpoint.Response;
  * Contains the logic for sending delete requests.
  */
 public class DeleteRequest extends Request {
-    private final Endpoint endpoint;
 
     /**
      * Constructor for DeleteRequest.
@@ -20,8 +19,7 @@ public class DeleteRequest extends Request {
      * @param endpoint endpoint to make API call on
      */
     public DeleteRequest(Endpoint endpoint) {
-        super(endpoint.getMethod().getMethodType(), endpoint.getAddress().value);
-        this.endpoint = endpoint;
+        super(endpoint);
     }
 
     /**
@@ -31,8 +29,8 @@ public class DeleteRequest extends Request {
      */
     @Override
     public Response send() throws IOException, RequestException {
-        HttpDelete request = new HttpDelete(this.getAddress());
-        request = (HttpDelete) super.setHeaders(request, this.endpoint.getHeaders());
+        HttpDelete request = new HttpDelete(super.getAddress());
+        request = (HttpDelete) super.setHeaders(request, super.getHeaders());
         return super.execute(request);
     }
 }

--- a/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/GetRequest.java
@@ -12,7 +12,6 @@ import seedu.us.among.model.endpoint.Response;
  * Contains the logic for sending get requests.
  */
 public class GetRequest extends Request {
-    private final Endpoint endpoint;
 
     /**
      * Constructor for GetRequest.
@@ -20,8 +19,7 @@ public class GetRequest extends Request {
      * @param endpoint endpoint to make API call on
      */
     public GetRequest(Endpoint endpoint) {
-        super(endpoint.getMethod().getMethodType(), endpoint.getAddress().value);
-        this.endpoint = endpoint;
+        super(endpoint);
     }
 
     /**
@@ -31,8 +29,8 @@ public class GetRequest extends Request {
      */
     @Override
     public Response send() throws IOException, RequestException {
-        HttpGet request = new HttpGet(this.getAddress());
-        request = (HttpGet) super.setHeaders(request, this.endpoint.getHeaders());
+        HttpGet request = new HttpGet(super.getAddress());
+        request = (HttpGet) super.setHeaders(request, super.getHeaders());
         return super.execute(request);
     }
 }

--- a/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/PostRequest.java
@@ -13,16 +13,13 @@ import seedu.us.among.model.endpoint.Response;
  */
 public class PostRequest extends Request {
 
-    private final Endpoint endpoint;
-
     /**
      * Constructor for PostRequest.
      *
      * @param endpoint endpoint to make API call on
      */
     public PostRequest(Endpoint endpoint) {
-        super(endpoint.getMethod().getMethodType(), endpoint.getAddress().value);
-        this.endpoint = endpoint;
+        super(endpoint);
     }
 
     /**
@@ -32,10 +29,10 @@ public class PostRequest extends Request {
      */
     @Override
     public Response send() throws IOException, RequestException {
-        HttpPost request = new HttpPost(this.getAddress());
+        HttpPost request = new HttpPost(super.getAddress());
 
-        request = (HttpPost) super.setHeaders(request, this.endpoint.getHeaders());
-        request = (HttpPost) super.setData(request, this.endpoint.getData());
+        request = (HttpPost) super.setHeaders(request, super.getHeaders());
+        request = (HttpPost) super.setData(request, super.getData());
 
         return super.execute(request);
     }

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -21,6 +21,7 @@ import seedu.us.among.commons.util.JsonUtil;
 import seedu.us.among.commons.util.StringUtil;
 import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Data;
+import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.MethodType;
 import seedu.us.among.model.endpoint.Response;
 import seedu.us.among.model.endpoint.header.Header;
@@ -34,24 +35,35 @@ public abstract class Request {
 
     private final MethodType method;
     private final String address;
+    private final Set<Header> headers;
+    private final Data data;
 
     /**
      * Constructor for Request.
      *
-     * @param method request method
-     * @param address request address
+     * @param endpoint endpoint to make API call on
      */
-    public Request(MethodType method, String address) {
-        this.method = method;
-        this.address = address;
-    }
-
-    public MethodType getMethodType() {
-        return this.method;
+    public Request(Endpoint endpoint) {
+        this.method = endpoint.getMethod().getMethodType();
+        this.address = endpoint.getAddress().value;
+        this.headers = endpoint.getHeaders();
+        this.data = endpoint.getData();
     }
 
     public String getAddress() {
         return this.address;
+    }
+
+    public Set<Header> getHeaders() {
+        return this.headers;
+    }
+
+    public Data getData() {
+        return this.data;
+    }
+
+    public MethodType getMethod() {
+        return this.method;
     }
 
     public static CloseableHttpClient getHttpclient() {

--- a/src/main/java/seedu/us/among/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/us/among/model/util/SampleDataUtil.java
@@ -35,7 +35,7 @@ public class SampleDataUtil {
                     getTagSet("github", "interesting"), new Response()),
             new Endpoint(new Method("GET"),
                     new Address("https://api.data.gov.sg/v1/environment/2-hour-weather-forecast"),
-                    getHeaderSet("\"Accept: application/jso\""), getTagSet("singapore"), new Response()),
+                    getHeaderSet("\"Accept: application/json\""), getTagSet("singapore"), new Response()),
             new Endpoint(new Method("GET"), new Address("https://api.data.gov.sg/v1/transport/taxi-availability"),
                     getHeaderSet("\"Accept: application/vnd.geo+json\""),
                     getTagSet("singapore", "transport"), new Response()),


### PR DESCRIPTION
Other than some minor typos, the request class and the subclasses seem
to repeat the creation of the instance attribute endpoint.

Let's remove the duplication and modify the abstract request constructor
to take in an endpoint and save the corresponding details for further
usage by child classes via getters.

This way new child request classes need not declare an endpoint
attribute within the class and clean up the call to get headers and data
as well.

@tjtanjin Please verify if this change is ok as the original code is authored by you.

Fixes #222 