### PR TITLE
Add show command

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ShowCommand.java
@@ -1,0 +1,69 @@
+package seedu.us.among.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.us.among.commons.core.Messages;
+import seedu.us.among.commons.core.index.Index;
+import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.model.Model;
+import seedu.us.among.model.endpoint.Endpoint;
+
+/**
+ * Shows the details of an existing API endpoint identified using it's displayed
+ * index from the API endpoint list.
+ */
+public class ShowCommand extends Command {
+
+    public static final String COMMAND_WORD = "show";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the details of an existing API endpoint "
+            + "identified using it's displayed index from the API endpoint list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 ";
+
+    private final Index index;
+
+    /**
+     * @param index of the endpoint in the filtered endpoint list to show
+     */
+    public ShowCommand(Index index) {
+        requireNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Endpoint> lastShownList = model.getFilteredEndpointList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        }
+
+        Endpoint endpointToShow = lastShownList.get(index.getZeroBased());
+
+        return new CommandResult(endpointToShow.toString());
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ShowCommand)) {
+            return false;
+        }
+
+        // state check
+        ShowCommand command = (ShowCommand) other;
+        return this.index.equals(command.index);
+    }
+
+}

--- a/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
@@ -17,6 +17,7 @@ import seedu.us.among.logic.commands.ListCommand;
 import seedu.us.among.logic.commands.RemoveCommand;
 import seedu.us.among.logic.commands.RunCommand;
 import seedu.us.among.logic.commands.SendCommand;
+import seedu.us.among.logic.commands.ShowCommand;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
 /**
@@ -75,6 +76,9 @@ public class ImposterParser {
 
         case RunCommand.COMMAND_WORD:
             return new RunCommandParser().parse(arguments);
+
+        case ShowCommand.COMMAND_WORD:
+            return new ShowCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/us/among/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ShowCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.us.among.logic.parser;
+
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.us.among.commons.core.index.Index;
+import seedu.us.among.logic.commands.ShowCommand;
+import seedu.us.among.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ShowCommand object
+ */
+public class ShowCommandParser implements Parser<ShowCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ShowCommand
+     * and returns an ShowCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ShowCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ShowCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/seedu/us/among/logic/commands/ShowCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/ShowCommandTest.java
@@ -1,0 +1,40 @@
+package seedu.us.among.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.us.among.testutil.TypicalEndpoints.getTypicalEndpointList;
+import static seedu.us.among.testutil.TypicalIndexes.INDEX_FIRST_ENDPOINT;
+import static seedu.us.among.testutil.TypicalIndexes.INDEX_SECOND_ENDPOINT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.us.among.model.Model;
+import seedu.us.among.model.ModelManager;
+import seedu.us.among.model.UserPrefs;
+
+public class ShowCommandTest {
+
+    private Model model = new ModelManager(getTypicalEndpointList(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        final ShowCommand standardCommand = new ShowCommand(INDEX_FIRST_ENDPOINT);
+
+        // same values -> returns true
+        ShowCommand commandWithSameValues = new ShowCommand(INDEX_FIRST_ENDPOINT);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new ShowCommand(INDEX_SECOND_ENDPOINT)));
+    }
+
+}

--- a/src/test/java/seedu/us/among/logic/parser/ShowCommandParserTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/ShowCommandParserTest.java
@@ -1,0 +1,42 @@
+package seedu.us.among.logic.parser;
+
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.us.among.testutil.TypicalIndexes.INDEX_SECOND_ENDPOINT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.us.among.commons.core.index.Index;
+import seedu.us.among.logic.commands.ShowCommand;
+
+public class ShowCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            ShowCommand.MESSAGE_USAGE);
+
+    private ShowCommandParser parser = new ShowCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1c", MESSAGE_INVALID_FORMAT); // invalid number
+        assertParseFailure(parser, "one", MESSAGE_INVALID_FORMAT); // invalid number (should be numeric)
+    }
+
+    @Test
+    public void parse_indexSpecified_success() {
+        Index targetIndex = INDEX_SECOND_ENDPOINT;
+        String userInput = targetIndex.getOneBased() + "";
+        ShowCommand expectedCommand = new ShowCommand(targetIndex);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+
+}


### PR DESCRIPTION
Without show command, users are unable to view the details of the endpoints saved.

Let's add a show command whereby users can specify the index to view the
the particular endpoint on the display panel on the right.

Show command takes the form of show 1.

Fixes #203 
Fixes #202 