### PR TITLE
Refactor: change ctrl + c event to be captured only during api call

### DIFF
--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -1,13 +1,22 @@
 package seedu.us.among.ui;
 
+import java.io.IOException;
+
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import javafx.stage.Stage;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.Request;
 import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
@@ -21,6 +30,10 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandExecutor commandExecutor;
     private ResultDisplay resultDisplay;
+    private Stage primaryStage;
+
+    // Handle ctrl+c event for cancelling API calls
+    private EventHandler<KeyEvent> keyEventHandler;
 
     @FXML
     private TextField commandTextField;
@@ -28,20 +41,23 @@ public class CommandBox extends UiPart<Region> {
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor, ResultDisplay resultDisplay) {
+    public CommandBox(CommandExecutor commandExecutor, ResultDisplay resultDisplay, Stage primaryStage) {
         super(FXML);
         this.commandExecutor = commandExecutor;
         this.resultDisplay = resultDisplay;
+        this.primaryStage = primaryStage;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        initialiseKeyEventHandler();
     }
 
     /**
      * Handles the command received
      *
      * @param commandText command received from user
+     * @param isInThread boolean to flag if a command is being ran on a background thread
      */
-    private void handleCommand(String commandText) {
+    private void handleCommand(String commandText, boolean isInThread) {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
@@ -49,6 +65,9 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException | RequestException | IllegalArgumentException e) {
             setStyleToIndicateCommandFailure();
         } finally {
+            if (isInThread) {
+                unsetKeyEventHandler();
+            }
             commandTextField.setDisable(false);
         }
     }
@@ -62,7 +81,7 @@ public class CommandBox extends UiPart<Region> {
         //handle API commands input in new thread
         Task<Void> task = new Task<>() {
             @Override public Void call() {
-                handleCommand(commandText);
+                handleCommand(commandText, true);
                 //to select command box again after command execution in thread ends
                 Platform.runLater(() -> {
                     commandTextField.requestFocus();
@@ -89,9 +108,10 @@ public class CommandBox extends UiPart<Region> {
         String commandText = commandTextField.getText();
 
         if (commandText.startsWith("send ") || commandText.startsWith("run ")) {
+            setKeyEventHandler();
             handleCommandInNewThread(commandText);
         } else if (!commandText.equals("")) {
-            handleCommand(commandText);
+            handleCommand(commandText, false);
         } else {
             commandTextField.setDisable(false);
         }
@@ -115,6 +135,45 @@ public class CommandBox extends UiPart<Region> {
         }
 
         styleClass.add(ERROR_STYLE_CLASS);
+    }
+
+    /**
+     * Closes httpClient when ctrl + c is pressed.
+     *
+     * @param event key event for pressed keys
+     */
+    public void closeHttpClient(KeyEvent event) throws IOException {
+        KeyCombination kc = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
+        if (kc.match(event)) {
+            Request.getHttpclient().close();
+        }
+    }
+
+    /**
+     * Initialises key handler to be method for handling ctrl + c input.
+     */
+    public void initialiseKeyEventHandler() {
+        this.keyEventHandler = e -> {
+            try {
+                closeHttpClient(e);
+            } catch (IOException ioException) {
+                //logger.info("Unable to stop request: " + ioException.getMessage());
+            }
+        };
+    }
+
+    /**
+     * Sets the key event handler to look out for key input of ctrl + c from user.
+     */
+    public void setKeyEventHandler() {
+        primaryStage.addEventHandler(KeyEvent.KEY_PRESSED, this.keyEventHandler);
+    }
+
+    /**
+     * Unsets the key event handler that looks out for key input of ctrl + c from user.
+     */
+    public void unsetKeyEventHandler() {
+        primaryStage.addEventHandler(KeyEvent.KEY_PRESSED, this.keyEventHandler);
     }
 
     /**


### PR DESCRIPTION
Refactor code for ctrl + c event to only be captured when a request is being made. While the original code is unlikely to bug out, reducing the instances of the ctrl + c input being captured should also reduce chances of users encountering bugs.

Resolves #229 