### PR TITLE
Add test for RunCommand & RunCommandParser

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -35,7 +35,7 @@ public class RunCommand extends Command {
             + COMMAND_WORD + " "
             + PREFIX_METHOD + "get "
             + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{\"some\": \"data\"} "
+            + PREFIX_DATA + "{some: data} "
             + PREFIX_HEADER + "\"key: value\" "
             + PREFIX_HEADER + "\"key: value\"\n";
 

--- a/src/main/java/seedu/us/among/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/us/among/model/util/SampleDataUtil.java
@@ -89,4 +89,21 @@ public class SampleDataUtil {
         return Arrays.stream(strings).map(Header::new).collect(Collectors.toSet());
     }
 
+    /**
+     * Returns a valid endpoint containing response result.
+     */
+    public static Endpoint getSampleValidEndpoint() {
+        String responseEntity = "{\"data\":{\"id\":2,\"email\":\"janet.weaver@reqres.in\",\"first_name\":"
+                + "\"Janet\","
+                + "\"last_name\":\"Weaver\",\"avatar\":\"https://reqres.in/img/faces/2-image.jpg\"},"
+                + "\"support\":{\"url\":\"https://reqres.in/#support-heading\",\"text\":\"To keep ReqRes"
+                + " free, contributions towards server costs are appreciated!\"}}";
+        return new Endpoint(new Method("GET"), new Address("https://reqres.in/api/users/2"),
+                new Data(),
+                getHeaderSet("\"Content-Type: application/json\""),
+                getTagSet(),
+                new Response("", "200", "OK",
+                        "", responseEntity, ""));
+    }
+
 }

--- a/src/test/java/seedu/us/among/logic/commands/RunCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/RunCommandTest.java
@@ -1,0 +1,60 @@
+package seedu.us.among.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.us.among.testutil.Assert.assertThrows;
+import static seedu.us.among.testutil.TypicalEndpoints.getTypicalEndpointList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.us.among.commons.util.JsonUtil;
+import seedu.us.among.model.Model;
+import seedu.us.among.model.ModelManager;
+import seedu.us.among.model.UserPrefs;
+import seedu.us.among.model.endpoint.Endpoint;
+import seedu.us.among.model.util.SampleDataUtil;
+
+public class RunCommandTest {
+
+    private final Model model = new ModelManager(getTypicalEndpointList(), new UserPrefs());
+    private final Endpoint[] endpoints = SampleDataUtil.getSampleEndpoint();
+    private final Endpoint sampleValidEndpoint = SampleDataUtil.getSampleValidEndpoint();
+
+    @Test
+    public void constructor_nullEndpoint_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new RunCommand(null));
+    }
+
+    @Test
+    public void execute_endpoint_runSuccessful() throws Exception {
+        RunCommand standardCommand = new RunCommand(sampleValidEndpoint);
+        CommandResult commandResult = standardCommand.execute(model);
+        String expectedResponse = JsonUtil.toPrettyPrintJsonString(
+                sampleValidEndpoint.getResponse().getResponseEntity());
+        assertEquals(expectedResponse,
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void equals() {
+        final RunCommand standardCommand = new RunCommand(endpoints[0]);
+
+        // same values -> returns true
+        RunCommand commandWithSameValues = new RunCommand(endpoints[0]);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new RunCommand(endpoints[1])));
+    }
+
+}

--- a/src/test/java/seedu/us/among/logic/parser/RunCommandParserTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/RunCommandParserTest.java
@@ -1,0 +1,64 @@
+package seedu.us.among.logic.parser;
+
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.logic.commands.CommandTestUtil.ADDRESS_DESC_FACT;
+import static seedu.us.among.logic.commands.CommandTestUtil.METHOD_DESC_POST;
+import static seedu.us.among.logic.commands.CommandTestUtil.VALID_ADDRESS_FACT;
+import static seedu.us.among.logic.commands.CommandTestUtil.VALID_METHOD_POST;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.us.among.logic.commands.RunCommand;
+import seedu.us.among.model.endpoint.Address;
+import seedu.us.among.model.endpoint.Endpoint;
+import seedu.us.among.model.endpoint.Method;
+import seedu.us.among.model.endpoint.header.Header;
+import seedu.us.among.model.tag.Tag;
+
+public class RunCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            RunCommand.MESSAGE_USAGE);
+
+    private RunCommandParser parser = new RunCommandParser();
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, RunCommand.MESSAGE_USAGE);
+
+        // missing method prefix
+        assertParseFailure(parser, VALID_METHOD_POST + ADDRESS_DESC_FACT, expectedMessage);
+
+        // missing address
+        assertParseFailure(parser, METHOD_DESC_POST + PREFIX_ADDRESS, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_METHOD_POST + VALID_ADDRESS_FACT, expectedMessage);
+    }
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "website", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-xget -uurl", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        String userInput = " -x get -u https://the-one-api.dev/v2/book";
+        RunCommand expectedCommand = new RunCommand(
+                new Endpoint(new Method("get"), new Address("https://the-one-api.dev/v2/book"),
+                        new HashSet<Header>(), new HashSet<Tag>()));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+}


### PR DESCRIPTION
Regression might occur without proper testing.

Let's add test cases for both RunCommand and RunCommandParser.

This will enforce functionality of RunCommand & RunCommandParser to be
in working condition.

Fixes: #224 
Fixes: #225 