### PR TITLE
Feat: add toggle command for user to switch theme

### DIFF
--- a/src/main/java/seedu/us/among/commons/util/StringUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/StringUtil.java
@@ -107,4 +107,35 @@ public class StringUtil {
         return String.format("%s seconds", get3DecimalPlace(value));
     }
 
+    //Solution below taken from https://www.javacodeexamples.com/convert-string-to-title-case-in-java-example/641
+    /**
+     * Returns word in title case.
+     *
+     * @param str string to return in title case
+     * @return string with title case
+     */
+    public static String toTitleCase(String str) {
+
+        if (str == null || str.isEmpty()) {
+            return "";
+        }
+
+        if (str.length() == 1) {
+            return str.toUpperCase();
+        }
+
+        String[] parts = str.split(" ");
+
+        StringBuilder sb = new StringBuilder(str.length());
+
+        for (String part : parts) {
+            char[] charArray = part.toLowerCase().toCharArray();
+            charArray[0] = Character.toUpperCase(charArray[0]);
+
+            sb.append(new String(charArray)).append(" ");
+        }
+
+        return sb.toString().trim();
+    }
+
 }

--- a/src/main/java/seedu/us/among/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/us/among/logic/commands/CommandResult.java
@@ -22,6 +22,9 @@ public class CommandResult {
     /** API response should be shown to the user. */
     private final boolean isApiResponse;
 
+    /** Toggle should be done. */
+    private final String toggleTheme;
+
     /** API endpoint to be consumed by the UI for displaying response. */
     private final Endpoint endpoint;
 
@@ -34,6 +37,7 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.isApiResponse = false;
+        this.toggleTheme = null;
         this.endpoint = null;
     }
 
@@ -46,7 +50,20 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.isApiResponse = isApiResponse;
+        this.toggleTheme = null;
         this.endpoint = endpoint;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields, including the newly added theme to toggle.
+     */
+    public CommandResult(String feedbackToUser, String themeToToggle) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showHelp = false;
+        this.exit = false;
+        this.isApiResponse = false;
+        this.toggleTheme = themeToToggle;
+        this.endpoint = null;
     }
 
     /**
@@ -75,6 +92,10 @@ public class CommandResult {
 
     public boolean isApiResponse() {
         return isApiResponse;
+    }
+
+    public String getToggleTheme() {
+        return this.toggleTheme;
     }
 
     @Override

--- a/src/main/java/seedu/us/among/logic/commands/ToggleCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ToggleCommand.java
@@ -1,0 +1,51 @@
+package seedu.us.among.logic.commands;
+
+import static seedu.us.among.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.us.among.logic.commands.exceptions.CommandException;
+import seedu.us.among.logic.endpoint.exceptions.RequestException;
+import seedu.us.among.model.Model;
+
+/**
+ * Toggles the theme of the application based on user input.
+ */
+public class ToggleCommand extends Command {
+
+    public static final String COMMAND_WORD = "toggle";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Toggles the theme of the application.\n"
+            + "Parameters: THEME (currently supported themes are light/dark)\n"
+            + "Example: " + COMMAND_WORD + " light";
+
+    private final String theme;
+
+    /**
+     * @param theme to toggle to
+     */
+    public ToggleCommand(String theme) {
+        requireAllNonNull(theme);
+        this.theme = theme;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException, RequestException {
+        return new CommandResult("You have set the application theme to " + theme + ".", theme);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ToggleCommand)) {
+            return false;
+        }
+
+        // state check
+        ToggleCommand e = (ToggleCommand) other;
+        return theme.equals(e.theme);
+    }
+}

--- a/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ImposterParser.java
@@ -18,6 +18,7 @@ import seedu.us.among.logic.commands.RemoveCommand;
 import seedu.us.among.logic.commands.RunCommand;
 import seedu.us.among.logic.commands.SendCommand;
 import seedu.us.among.logic.commands.ShowCommand;
+import seedu.us.among.logic.commands.ToggleCommand;
 import seedu.us.among.logic.parser.exceptions.ParseException;
 
 /**
@@ -79,6 +80,9 @@ public class ImposterParser {
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);
+
+        case ToggleCommand.COMMAND_WORD:
+            return new ToggleCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/us/among/logic/parser/ToggleCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ToggleCommandParser.java
@@ -1,0 +1,49 @@
+package seedu.us.among.logic.parser;
+
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.us.among.logic.commands.ToggleCommand;
+import seedu.us.among.logic.parser.exceptions.ParseException;
+import seedu.us.among.ui.ThemeType;
+
+/**
+ * Parses input arguments and creates a new ToggleCommand object
+ */
+public class ToggleCommandParser implements Parser<ToggleCommand> {
+    public static final String MESSAGE_INVALID_THEME = "You may only toggle to supported themes."
+            + " \n%1$s";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ToggleCommand
+     * and returns a ToggleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ToggleCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ToggleCommand.MESSAGE_USAGE));
+        }
+
+        String[] themedKeyword = trimmedArgs.split("\\s+");
+        String theme = themedKeyword[0];
+        if (!isValidTheme(theme)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_THEME, ToggleCommand.MESSAGE_USAGE));
+        }
+
+        return new ToggleCommand(theme);
+    }
+
+    /**
+     * Returns true if a given string is a valid theme.
+     */
+    public static boolean isValidTheme(String theme) {
+        for (ThemeType e : ThemeType.values()) {
+            if (e.name().equalsIgnoreCase(theme)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/us/among/ui/MainWindow.java
+++ b/src/main/java/seedu/us/among/ui/MainWindow.java
@@ -13,6 +13,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.us.among.commons.core.GuiSettings;
 import seedu.us.among.commons.core.LogsCenter;
+import seedu.us.among.commons.util.StringUtil;
 import seedu.us.among.logic.Logic;
 import seedu.us.among.logic.commands.CommandResult;
 import seedu.us.among.logic.commands.exceptions.CommandException;
@@ -199,6 +200,10 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            if (commandResult.getToggleTheme() != null) {
+                updateTheme(commandResult.getToggleTheme());
+            }
+
             return commandResult;
         } catch (CommandException | ParseException | RequestException e) {
             //stop loading spinner (if any)
@@ -213,5 +218,30 @@ public class MainWindow extends UiPart<Stage> {
         } finally {
             System.out.println(Thread.activeCount());
         }
+    }
+
+    /**
+     * Updates theme for the application.
+     *
+     * @param theme theme to update with
+     */
+    public void updateTheme(String theme) {
+        for (ThemeType e : ThemeType.values()) {
+            if (!e.name().equalsIgnoreCase(theme)) {
+                getRoot().getScene().getStylesheets().remove(getThemeFilePath(e.name()));
+            } else {
+                getRoot().getScene().getStylesheets().add(getThemeFilePath(theme));
+            }
+        }
+    }
+
+    /**
+     * Gets the file path for the theme.
+     *
+     * @param theme theme to get file path for
+     * @return
+     */
+    public String getThemeFilePath(String theme) {
+        return "view/" + StringUtil.toTitleCase(theme) + "Theme.css";
     }
 }

--- a/src/main/java/seedu/us/among/ui/ThemeType.java
+++ b/src/main/java/seedu/us/among/ui/ThemeType.java
@@ -1,0 +1,5 @@
+package seedu.us.among.ui;
+
+public enum ThemeType {
+    LIGHT, DARK
+}

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -1,0 +1,369 @@
+.background {
+    -fx-background-color: derive(#F2F2F2, 20%);
+    background-color: #D3D3D3; /* Used in the default.html file */
+}
+
+.label {
+    -fx-font-size: 11pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: #808080;
+    -fx-opacity: 0.9;
+}
+
+.label-bright {
+    -fx-font-size: 11pt;
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-text-fill: black;
+    -fx-opacity: 1;
+}
+
+.label-header {
+    -fx-font-size: 32pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: black;
+    -fx-opacity: 1;
+}
+
+.text-field {
+    -fx-font-size: 12pt;
+    -fx-font-family: "Segoe UI Semibold";
+}
+
+.tab-pane {
+    -fx-padding: 0 0 0 1;
+}
+
+.tab-pane .tab-header-area {
+    -fx-padding: 0 0 0 0;
+    -fx-min-height: 0;
+    -fx-max-height: 0;
+}
+
+.table-view {
+    -fx-base: #F2F2F2;
+    -fx-control-inner-background: #F2F2F2;
+    -fx-background-color: #F2F2F2;
+    -fx-table-cell-border-color: transparent;
+    -fx-table-header-border-color: transparent;
+    -fx-padding: 5;
+}
+
+.table-view .column-header-background {
+    -fx-background-color: transparent;
+}
+
+.table-view .column-header, .table-view .filler {
+    -fx-size: 35;
+    -fx-border-width: 0 0 1 0;
+    -fx-background-color: transparent;
+    -fx-border-color:
+        transparent
+        transparent
+        derive(-fx-base, 80%)
+        transparent;
+    -fx-border-insets: 0 10 1 0;
+}
+
+.table-view .column-header .label {
+    -fx-font-size: 20pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: black;
+    -fx-alignment: center-left;
+    -fx-opacity: 1;
+}
+
+.table-view:focused .table-row-cell:filled:focused:selected {
+    -fx-background-color: -fx-focus-color;
+}
+
+.split-pane:horizontal .split-pane-divider {
+    -fx-background-color: derive(#F2F2F2, 20%);
+    -fx-border-color: transparent transparent transparent #4d4d4d;
+}
+
+.split-pane {
+    -fx-border-radius: 1;
+    -fx-border-width: 1;
+    -fx-background-color: derive(#F2F2F2, 20%);
+}
+
+.list-view {
+    -fx-background-insets: 0;
+    -fx-padding: 0;
+    -fx-background-color: derive(#F2F2F2, 20%);
+}
+
+.list-cell {
+    -fx-label-padding: 0 0 0 0;
+    -fx-graphic-text-gap : 0;
+    -fx-padding: 0 0 0 0;
+}
+
+.list-cell:filled:even {
+    -fx-background-color: #DCDCDC;
+}
+
+.list-cell:filled:odd {
+    -fx-background-color: #C0C0C0;
+}
+
+.list-cell:filled:selected {
+    -fx-background-color: #add8e6;
+}
+
+.list-cell:filled:selected #cardPane {
+    -fx-border-color: #3e7b91;
+    -fx-border-width: 1;
+}
+
+.list-cell .label {
+    -fx-text-fill: black;
+}
+
+.cell_big_label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 16px;
+    -fx-text-fill: #010504;
+}
+
+.cell_small_label {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 13px;
+    -fx-text-fill: #010504;
+}
+
+.stack-pane {
+     -fx-background-color: derive(#F2F2F2, 20%);
+}
+
+.pane-with-border {
+     -fx-background-color: derive(#F2F2F2, 20%);
+     -fx-border-color: derive(#F2F2F2, 10%);
+     -fx-border-top-width: 1px;
+}
+
+.status-bar {
+    -fx-background-color: derive(#F2F2F2, 30%);
+}
+
+.result-display {
+    -fx-background-color: transparent;
+    -fx-font-family: "Segoe UI Light";
+    -fx-font-size: 13pt;
+    -fx-text-fill: black;
+}
+
+.result-display .label {
+    -fx-text-fill: black !important;
+}
+
+.status-bar .label {
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: black;
+    -fx-padding: 4px;
+    -fx-pref-height: 30px;
+}
+
+.status-bar-with-border {
+    -fx-background-color: derive(#F2F2F2, 30%);
+    -fx-border-color: derive(#F2F2F2, 25%);
+    -fx-border-width: 1px;
+}
+
+.status-bar-with-border .label {
+    -fx-text-fill: black;
+}
+
+.grid-pane {
+    -fx-background-color: derive(#F2F2F2, 30%);
+    -fx-border-color: derive(#F2F2F2, 30%);
+    -fx-border-width: 1px;
+}
+
+.grid-pane .stack-pane {
+    -fx-background-color: derive(#F2F2F2, 30%);
+}
+
+.context-menu {
+    -fx-background-color: derive(#F2F2F2, 50%);
+}
+
+.context-menu .label {
+    -fx-text-fill: black;
+}
+
+.menu-bar {
+    -fx-background-color: derive(#F2F2F2, 20%);
+}
+
+.menu-bar .label {
+    -fx-font-size: 14pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: black;
+    -fx-opacity: 0.9;
+}
+
+.menu .left-container {
+    -fx-background-color: white;
+}
+
+/*
+ * Metro style Push Button
+ * Author: Pedro Duque Vieira
+ * http://pixelduke.wordpress.com/2012/10/23/jmetro-windows-8-controls-on-java/
+ */
+.button {
+    -fx-padding: 5 22 5 22;
+    -fx-border-color: #e2e2e2;
+    -fx-border-width: 2;
+    -fx-background-radius: 0;
+    -fx-background-color: #F2F2F2;
+    -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    -fx-font-size: 11pt;
+    -fx-text-fill: #d8d8d8;
+    -fx-background-insets: 0 0 0 0, 0, 1, 2;
+}
+
+.button:hover {
+    -fx-background-color: #3a3a3a;
+}
+
+.button:pressed, .button:default:hover:pressed {
+  -fx-background-color: black;
+  -fx-text-fill: #F2F2F2;
+}
+
+.button:focused {
+    -fx-border-color: black, black;
+    -fx-border-width: 1, 1;
+    -fx-border-style: solid, segments(1, 1);
+    -fx-border-radius: 0, 0;
+    -fx-border-insets: 1 1 1 1, 0;
+}
+
+.button:disabled, .button:default:disabled {
+    -fx-opacity: 0.4;
+    -fx-background-color: #F2F2F2;
+    -fx-text-fill: black;
+}
+
+.button:default {
+    -fx-background-color: -fx-focus-color;
+    -fx-text-fill: #ffffff;
+}
+
+.button:default:hover {
+    -fx-background-color: derive(-fx-focus-color, 30%);
+}
+
+.dialog-pane {
+    -fx-background-color: #F2F2F2;
+}
+
+.dialog-pane > *.button-bar > *.container {
+    -fx-background-color: #F2F2F2;
+}
+
+.dialog-pane > *.label.content {
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+    -fx-text-fill: black;
+}
+
+.dialog-pane:header *.header-panel {
+    -fx-background-color: derive(#F2F2F2, 25%);
+}
+
+.dialog-pane:header *.header-panel *.label {
+    -fx-font-size: 18px;
+    -fx-font-style: italic;
+    -fx-fill: black;
+    -fx-text-fill: black;
+}
+
+.scroll-bar {
+    -fx-background-color: derive(#A9A9A9, 20%);
+}
+
+.scroll-bar .thumb {
+    -fx-background-color: derive(#C0C0C0, 50%);
+    -fx-background-insets: 3;
+}
+
+.scroll-bar .increment-button, .scroll-bar .decrement-button {
+    -fx-background-color: transparent;
+    -fx-padding: 0 0 0 0;
+}
+
+.scroll-bar .increment-arrow, .scroll-bar .decrement-arrow {
+    -fx-shape: " ";
+}
+
+.scroll-bar:vertical .increment-arrow, .scroll-bar:vertical .decrement-arrow {
+    -fx-padding: 1 8 1 8;
+}
+
+.scroll-bar:horizontal .increment-arrow, .scroll-bar:horizontal .decrement-arrow {
+    -fx-padding: 8 1 8 1;
+}
+
+#cardPane {
+    -fx-background-color: transparent;
+    -fx-border-width: 0;
+}
+
+#commandTypeLabel {
+    -fx-font-size: 11px;
+    -fx-text-fill: #F70D1A;
+}
+
+#commandTextField {
+    -fx-background-color: transparent #D3D3D3 transparent #D3D3D3;
+    -fx-background-insets: 0;
+    -fx-border-color: #ffffff #ffffff #383838 #ffffff;
+    -fx-border-insets: 0;
+    -fx-border-width: 1;
+    -fx-font-family: "Segoe UI Light";
+    -fx-font-size: 13pt;
+    -fx-text-fill: black;
+}
+
+#filterField, #personListPanel, #personWebpage {
+    -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
+}
+
+#resultDisplay .content {
+    -fx-background-color: transparent, #D3D3D3, transparent, #D3D3D3;
+    -fx-background-radius: 0;
+}
+
+#tags {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#tags .label {
+    -fx-text-fill: black;
+    -fx-background-color: #40E0D0;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+#responseMeta {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#responseMeta .label {
+    -fx-text-fill: black;
+    -fx-background-color: #000000;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+    -fx-z-index: -1;
+}
+
+


### PR DESCRIPTION
Add new toggle command for user to choose the application theme. The following changes were made:
- Toggle command added, usage is straightforward (e.g. `toggle light`).
- Adding of new themes has been made easy, it takes only the following two steps:
    1) Go within `seedu.us.among.ui.ThemeType` and add your new theme to the enum.
    2) Add your new theme file under `resources/view` (e.g. `TestTheme.css`).

If anyone has good theme suggestions or are great with design in general, please go ahead and add more themes. Light theme itself while now supported can still use more visual improvements.

Closes #237 
Resolves #238 