### PR TITLE
Fix: minor refactor and fix bug with cancelling requests

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -80,11 +80,11 @@ public class SendCommand extends Command {
             response = epc.callEndpoint();
         } catch (UnknownHostException e) {
             throw new RequestException(MESSAGE_UNKNOWN_HOST);
-        } catch (ClientProtocolException | SocketTimeoutException | SocketException | NoHttpResponseException e) {
+        } catch (ClientProtocolException | SocketTimeoutException | SocketException e) {
             throw new RequestException(MESSAGE_CONNECTION_ERROR);
         } catch (JsonParseException e) {
             throw new RequestException(MESSAGE_INVALID_JSON);
-        } catch (IllegalStateException | SSLException e) {
+        } catch (IllegalStateException | SSLException | NoHttpResponseException e) {
             throw new RequestException(MESSAGE_CALL_CANCELLED);
         } catch (IOException e) {
             throw new RequestException(MESSAGE_GENERAL_ERROR);

--- a/src/main/java/seedu/us/among/logic/endpoint/Request.java
+++ b/src/main/java/seedu/us/among/logic/endpoint/Request.java
@@ -31,7 +31,7 @@ import seedu.us.among.model.endpoint.header.Header;
  */
 public abstract class Request {
     public static final int CONVERT_NANO_SECONDS = 1_000_000_000;
-    private static final CloseableHttpClient httpclient = createHttpClient();
+    private static CloseableHttpClient httpclient = createHttpClient();
     private static final int TIMEOUT = 60 * 1000;
 
     private final MethodType method;
@@ -122,6 +122,7 @@ public abstract class Request {
         // double try is needed because we want to time the execution as accurately as possible
         // also that the following will auto close httpClient and response
         try (CloseableHttpClient httpClient = createHttpClient()) {
+            Request.httpclient = httpClient;
             long start = System.nanoTime();
             try (CloseableHttpResponse response = httpClient.execute(request)) {
                 long end = System.nanoTime();

--- a/src/main/java/seedu/us/among/ui/CommandBox.java
+++ b/src/main/java/seedu/us/among/ui/CommandBox.java
@@ -143,7 +143,7 @@ public class CommandBox extends UiPart<Region> {
      * @param event key event for pressed keys
      */
     public void closeHttpClient(KeyEvent event) throws IOException {
-        KeyCombination kc = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
+        KeyCombination kc = new KeyCodeCombination(KeyCode.D, KeyCombination.CONTROL_DOWN);
         if (kc.match(event)) {
             Request.getHttpclient().close();
         }


### PR DESCRIPTION
The cancelling of request was broken after recent PRs. The following changes were made to fix it as well as make a few improvements:
- `httpClient` attribute in `Request` is now properly assigned after a connection is established.
- `NoHttpResponseException` is now properly caught.
- `ctrl + d` is now used to cancel a request due to overlapping copy functionalities with `ctrl + c`.

Fixes #245 