### PR TITLE
Fix edit command error msg

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/AddCommand.java
@@ -20,18 +20,18 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_API_EXAMPLE_1 = "1. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{\"some\": \"data\"} "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_TAG + "local "
-            + PREFIX_TAG + "data\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " http://localhost:3000/ "
+            + PREFIX_DATA + " {\"some\": \"data\"} "
+            + PREFIX_HEADER + " \"key1: value1\" "
+            + PREFIX_HEADER + " \"key2: value2\" "
+            + PREFIX_TAG + " local "
+            + PREFIX_TAG + " data\n";
 
     public static final String MESSAGE_API_EXAMPLE_2 = "2. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature ";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature ";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an API endpoint to the API endpoint list.\n"

--- a/src/main/java/seedu/us/among/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/EditCommand.java
@@ -33,17 +33,53 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
+    public static final String MESSAGE_API_EXAMPLE_1 = "1. "
+            + COMMAND_WORD + " " + " 1 "
+            + PREFIX_METHOD + " get \n";
+
+    public static final String MESSAGE_API_EXAMPLE_2 = "2. "
+            + COMMAND_WORD + " " + " 2 "
+            + PREFIX_ADDRESS + " http://localhost:3000/ \n";
+
+    public static final String MESSAGE_API_EXAMPLE_3 = "3. "
+            + COMMAND_WORD + " " + " 3 "
+            + PREFIX_DATA + " {\"some\": \"new data\"} \n";
+
+    public static final String MESSAGE_API_EXAMPLE_4 = "4. "
+            + COMMAND_WORD + " " + " 4 "
+            + PREFIX_HEADER + " \"new key1: new value1\" "
+            + PREFIX_HEADER + " \"new key2: new value2\" \n";
+
+    public static final String MESSAGE_API_EXAMPLE_5 = "5. "
+            + COMMAND_WORD + " " + " 5 "
+            + PREFIX_TAG + " newtagone "
+            + PREFIX_TAG + " newtagtwo \n";
+
+    public static final String MESSAGE_API_EXAMPLE_6 = "6. "
+            + COMMAND_WORD + " " + " 6 "
+            + PREFIX_HEADER + " //remove all headers \n";
+
+    public static final String MESSAGE_API_EXAMPLE_7 = "7. "
+            + COMMAND_WORD + " " + " 7 "
+            + PREFIX_TAG + " //removes all tags \n";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of an existing API endpoint "
             + "identified using it's displayed index from the API endpoint list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_METHOD + "METHOD] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_DATA + "DATA] "
-            + "[" + PREFIX_HEADER + "HEADER]...\n"
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_ADDRESS + "wall street ";
+            + "[" + PREFIX_METHOD + " METHOD] "
+            + "[" + PREFIX_ADDRESS + " ADDRESS] "
+            + "[" + PREFIX_DATA + " DATA] "
+            + "[" + PREFIX_HEADER + " HEADER]... "
+            + "[" + PREFIX_TAG + " TAG]...\n"
+            + "Examples: \n"
+            + MESSAGE_API_EXAMPLE_1
+            + MESSAGE_API_EXAMPLE_2
+            + MESSAGE_API_EXAMPLE_3
+            + MESSAGE_API_EXAMPLE_4
+            + MESSAGE_API_EXAMPLE_5
+            + MESSAGE_API_EXAMPLE_6
+            + MESSAGE_API_EXAMPLE_7;
 
     public static final String MESSAGE_EDIT_ENDPOINT_SUCCESS = "Edited endpoint: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -31,16 +31,16 @@ public class RunCommand extends Command {
 
     public static final String MESSAGE_API_EXAMPLE_1 = "1. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{some: data} "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_HEADER + "\"key: value\"\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " http://localhost:3000/ "
+            + PREFIX_DATA + " {some: data} "
+            + PREFIX_HEADER + " \"key: value\" "
+            + PREFIX_HEADER + " \"key: value\"\n";
 
     public static final String MESSAGE_API_EXAMPLE_2 = "2. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature\n";
 
     public static final String QUICK_RUN_COMMAND_SYNTAX = "Tip (Only for 10x developers):\n"
             + "Run command has a special syntax! Simply specify the API address to be tested"
@@ -60,7 +60,7 @@ public class RunCommand extends Command {
             + "[" + PREFIX_HEADER + " HEADER]...\n"
             + "Examples:\n"
             + MESSAGE_API_EXAMPLE_1
-            + MESSAGE_API_EXAMPLE_2
+            + MESSAGE_API_EXAMPLE_2 + "\n"
             + QUICK_RUN_COMMAND_SYNTAX;
 
 

--- a/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
@@ -7,10 +7,10 @@ package seedu.us.among.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_METHOD = new Prefix("-x ");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("-u ");
-    public static final Prefix PREFIX_TAG = new Prefix("-t ");
-    public static final Prefix PREFIX_HEADER = new Prefix("-h ");
-    public static final Prefix PREFIX_DATA = new Prefix("-d ");
+    public static final Prefix PREFIX_METHOD = new Prefix("-x");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-u");
+    public static final Prefix PREFIX_TAG = new Prefix("-t");
+    public static final Prefix PREFIX_HEADER = new Prefix("-h");
+    public static final Prefix PREFIX_DATA = new Prefix("-d");
 
 }

--- a/src/test/java/seedu/us/among/testutil/EndpointUtil.java
+++ b/src/test/java/seedu/us/among/testutil/EndpointUtil.java
@@ -43,16 +43,25 @@ public class EndpointUtil {
      */
     public static String getEditEndpointDescriptorDetails(EditCommand.EditEndpointDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getMethod().ifPresent(name -> sb.append(PREFIX_METHOD).append(name.methodName).append(" "));
-        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
-        descriptor.getData().ifPresent(data -> sb.append(PREFIX_DATA).append(data.value).append(" "));
+        descriptor.getMethod().ifPresent(name -> sb.append(PREFIX_METHOD)
+                .append(" ")
+                .append(name.methodName)
+                .append(" "));
+        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS)
+                .append(" ")
+                .append(address.value)
+                .append(" "));
+        descriptor.getData().ifPresent(data -> sb.append(PREFIX_DATA)
+                .append(" ")
+                .append(data.value)
+                .append(" "));
 
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(" ");
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(" ").append(s.tagName).append(" "));
             }
         }
         if (descriptor.getHeaders().isPresent()) {
@@ -60,7 +69,7 @@ public class EndpointUtil {
             if (headers.isEmpty()) {
                 sb.append(PREFIX_HEADER);
             } else {
-                headers.forEach(s -> sb.append(PREFIX_HEADER).append(s.headerName).append(" "));
+                headers.forEach(s -> sb.append(PREFIX_HEADER).append(" ").append(s.headerName).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
 and made sure other command error msgs were properly formatted

The error is that if there is a space in PREFIX_METHOD and other prefixs, it will messes up how the index is parsed, and also messes up some functionalities like "edit 1 -t " in order to take away existing tags

closes #210 