### PR TITLE
Commands: Find Command Advanced Functionality

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/AddCommand.java
@@ -20,18 +20,18 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_API_EXAMPLE_1 = "1. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{\"some\": \"data\"} "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_TAG + "local "
-            + PREFIX_TAG + "data\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " http://localhost:3000/ "
+            + PREFIX_DATA + " {\"some\": \"data\"} "
+            + PREFIX_HEADER + " \"key1: value1\" "
+            + PREFIX_HEADER + " \"key2: value2\" "
+            + PREFIX_TAG + " local "
+            + PREFIX_TAG + " data\n";
 
     public static final String MESSAGE_API_EXAMPLE_2 = "2. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature ";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature ";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an API endpoint to the API endpoint list.\n"

--- a/src/main/java/seedu/us/among/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/EditCommand.java
@@ -33,17 +33,53 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
+    public static final String MESSAGE_API_EXAMPLE_1 = "1. "
+            + COMMAND_WORD + " " + " 1 "
+            + PREFIX_METHOD + " get \n";
+
+    public static final String MESSAGE_API_EXAMPLE_2 = "2. "
+            + COMMAND_WORD + " " + " 2 "
+            + PREFIX_ADDRESS + " http://localhost:3000/ \n";
+
+    public static final String MESSAGE_API_EXAMPLE_3 = "3. "
+            + COMMAND_WORD + " " + " 3 "
+            + PREFIX_DATA + " {\"some\": \"new data\"} \n";
+
+    public static final String MESSAGE_API_EXAMPLE_4 = "4. "
+            + COMMAND_WORD + " " + " 4 "
+            + PREFIX_HEADER + " \"new key1: new value1\" "
+            + PREFIX_HEADER + " \"new key2: new value2\" \n";
+
+    public static final String MESSAGE_API_EXAMPLE_5 = "5. "
+            + COMMAND_WORD + " " + " 5 "
+            + PREFIX_TAG + " newtagone "
+            + PREFIX_TAG + " newtagtwo \n";
+
+    public static final String MESSAGE_API_EXAMPLE_6 = "6. "
+            + COMMAND_WORD + " " + " 6 "
+            + PREFIX_HEADER + " //remove all headers \n";
+
+    public static final String MESSAGE_API_EXAMPLE_7 = "7. "
+            + COMMAND_WORD + " " + " 7 "
+            + PREFIX_TAG + " //removes all tags \n";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of an existing API endpoint "
             + "identified using it's displayed index from the API endpoint list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_METHOD + "METHOD] "
-            + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_DATA + "DATA] "
-            + "[" + PREFIX_HEADER + "HEADER]...\n"
-            + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_ADDRESS + "wall street ";
+            + "[" + PREFIX_METHOD + " METHOD] "
+            + "[" + PREFIX_ADDRESS + " ADDRESS] "
+            + "[" + PREFIX_DATA + " DATA] "
+            + "[" + PREFIX_HEADER + " HEADER]... "
+            + "[" + PREFIX_TAG + " TAG]...\n"
+            + "Examples: \n"
+            + MESSAGE_API_EXAMPLE_1
+            + MESSAGE_API_EXAMPLE_2
+            + MESSAGE_API_EXAMPLE_3
+            + MESSAGE_API_EXAMPLE_4
+            + MESSAGE_API_EXAMPLE_5
+            + MESSAGE_API_EXAMPLE_6
+            + MESSAGE_API_EXAMPLE_7;
 
     public static final String MESSAGE_EDIT_ENDPOINT_SUCCESS = "Edited endpoint: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/us/among/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/FindCommand.java
@@ -2,9 +2,11 @@ package seedu.us.among.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.us.among.commons.core.Messages;
 import seedu.us.among.model.Model;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.Endpoint;
 
 /**
  * Finds and lists all API endpoints whose fields contain any of the argument keywords.
@@ -19,9 +21,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " get facebook google";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Endpoint> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Endpoint> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -31,16 +31,16 @@ public class RunCommand extends Command {
 
     public static final String MESSAGE_API_EXAMPLE_1 = "1. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "http://localhost:3000/ "
-            + PREFIX_DATA + "{some: data} "
-            + PREFIX_HEADER + "\"key: value\" "
-            + PREFIX_HEADER + "\"key: value\"\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " http://localhost:3000/ "
+            + PREFIX_DATA + " {some: data} "
+            + PREFIX_HEADER + " \"key: value\" "
+            + PREFIX_HEADER + " \"key: value\"\n";
 
     public static final String MESSAGE_API_EXAMPLE_2 = "2. "
             + COMMAND_WORD + " "
-            + PREFIX_METHOD + "get "
-            + PREFIX_ADDRESS + "https://api.data.gov.sg/v1/environment/air-temperature\n";
+            + PREFIX_METHOD + " get "
+            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature\n";
 
     public static final String QUICK_RUN_COMMAND_SYNTAX = "Tip (Only for 10x developers):\n"
             + "Run command has a special syntax! Simply specify the API address to be tested"
@@ -60,7 +60,7 @@ public class RunCommand extends Command {
             + "[" + PREFIX_HEADER + " HEADER]...\n"
             + "Examples:\n"
             + MESSAGE_API_EXAMPLE_1
-            + MESSAGE_API_EXAMPLE_2
+            + MESSAGE_API_EXAMPLE_2 + "\n"
             + QUICK_RUN_COMMAND_SYNTAX;
 
 

--- a/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/us/among/logic/parser/CliSyntax.java
@@ -7,10 +7,10 @@ package seedu.us.among.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_METHOD = new Prefix("-x ");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("-u ");
-    public static final Prefix PREFIX_TAG = new Prefix("-t ");
-    public static final Prefix PREFIX_HEADER = new Prefix("-h ");
-    public static final Prefix PREFIX_DATA = new Prefix("-d ");
+    public static final Prefix PREFIX_METHOD = new Prefix("-x");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("-u");
+    public static final Prefix PREFIX_TAG = new Prefix("-t");
+    public static final Prefix PREFIX_HEADER = new Prefix("-h");
+    public static final Prefix PREFIX_DATA = new Prefix("-d");
 
 }

--- a/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
@@ -1,12 +1,22 @@
 package seedu.us.among.logic.parser;
 
 import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_DATA;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_HEADER;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_METHOD;
+import static seedu.us.among.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 
 import seedu.us.among.logic.commands.FindCommand;
 import seedu.us.among.logic.parser.exceptions.ParseException;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.AddressContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.DataContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.HeadersContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.MethodContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.TagsContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +29,58 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args,
+                PREFIX_METHOD,
+                PREFIX_ADDRESS,
+                PREFIX_DATA,
+                PREFIX_HEADER,
+                PREFIX_TAG);
+
+        String[] nameKeywords;
+
+        if (argMultimap.arePrefixesPresent(PREFIX_METHOD)) {
+            String input = argMultimap.getValue(PREFIX_METHOD).get();
+            nameKeywords = getNameKeywords(input);
+            return new FindCommand(new MethodContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        if (argMultimap.arePrefixesPresent(PREFIX_ADDRESS)) {
+            String input = argMultimap.getValue(PREFIX_ADDRESS).get();
+            nameKeywords = getNameKeywords(input);
+            return new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        if (argMultimap.arePrefixesPresent(PREFIX_DATA)) {
+            String input = argMultimap.getValue(PREFIX_DATA).get();
+            nameKeywords = getNameKeywords(input);
+            return new FindCommand(new DataContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        if (argMultimap.arePrefixesPresent(PREFIX_HEADER)) {
+            String input = argMultimap.getValue(PREFIX_HEADER).get();
+            nameKeywords = getNameKeywords(input);
+            return new FindCommand(new HeadersContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        if (argMultimap.arePrefixesPresent(PREFIX_TAG)) {
+            String input = argMultimap.getValue(PREFIX_TAG).get();
+            nameKeywords = getNameKeywords(input);
+            return new FindCommand(new TagsContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+
+        nameKeywords = getNameKeywords(args);
+        return new FindCommand(new EndPointContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    public String[] getNameKeywords(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return trimmedArgs.split("\\s+");
     }
 
 }

--- a/src/main/java/seedu/us/among/model/endpoint/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.us.among.model.endpoint;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.us.among.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
+ * given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Endpoint> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Endpoint endpoint) {
+        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsPartialWordIgnoreCase(endpoint.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddressContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((AddressContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/us/among/model/endpoint/DataContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/DataContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.us.among.model.endpoint;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.us.among.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
+ * given.
+ */
+public class DataContainsKeywordsPredicate implements Predicate<Endpoint> {
+    private final List<String> keywords;
+
+    public DataContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Endpoint endpoint) {
+        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsPartialWordIgnoreCase(endpoint.getData().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DataContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((DataContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/us/among/model/endpoint/EndPointContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/EndPointContainsKeywordsPredicate.java
@@ -9,20 +9,21 @@ import seedu.us.among.commons.util.StringUtil;
  * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
  * given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Endpoint> {
+public class EndPointContainsKeywordsPredicate implements Predicate<Endpoint> {
     private final List<String> keywords;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    public EndPointContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
     @Override
     public boolean test(Endpoint endpoint) {
-        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        //Currently allows for checking of PartialWords in method, address, data, tags and headers.
         return keywords.stream()
                 .anyMatch(keyword ->
                         StringUtil.containsPartialWordIgnoreCase(endpoint.getMethod().methodName, keyword)
                         || StringUtil.containsPartialWordIgnoreCase(endpoint.getTags().toString(), keyword)
+                        || StringUtil.containsPartialWordIgnoreCase(endpoint.getAddress().value, keyword)
                         || StringUtil.containsPartialWordIgnoreCase(endpoint.getData().value, keyword)
                         || StringUtil.containsPartialWordIgnoreCase(endpoint.getHeaders().toString(), keyword));
     }
@@ -30,8 +31,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Endpoint> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
-                        && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+                || (other instanceof EndPointContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((EndPointContainsKeywordsPredicate) other).keywords)); // state check
     }
 
 }

--- a/src/main/java/seedu/us/among/model/endpoint/HeadersContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/HeadersContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.us.among.model.endpoint;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.us.among.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
+ * given.
+ */
+public class HeadersContainsKeywordsPredicate implements Predicate<Endpoint> {
+    private final List<String> keywords;
+
+    public HeadersContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Endpoint endpoint) {
+        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsPartialWordIgnoreCase(endpoint.getHeaders().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof HeadersContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((HeadersContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/us/among/model/endpoint/MethodContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/MethodContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.us.among.model.endpoint;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.us.among.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
+ * given.
+ */
+public class MethodContainsKeywordsPredicate implements Predicate<Endpoint> {
+    private final List<String> keywords;
+
+    public MethodContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Endpoint endpoint) {
+        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsPartialWordIgnoreCase(endpoint.getMethod().methodName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof MethodContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((MethodContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/us/among/model/endpoint/TagsContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/us/among/model/endpoint/TagsContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.us.among.model.endpoint;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.us.among.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Endpoint}'s {@code Name} matches any of the keywords
+ * given.
+ */
+public class TagsContainsKeywordsPredicate implements Predicate<Endpoint> {
+    private final List<String> keywords;
+
+    public TagsContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Endpoint endpoint) {
+        //Currently allows for checking of PartialWords in method, data, tags and headers.
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsPartialWordIgnoreCase(endpoint.getTags().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagsContainsKeywordsPredicate // instanceof handles nulls
+                        && keywords.equals(((TagsContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_METHOD;
@@ -16,8 +17,8 @@ import seedu.us.among.logic.commands.exceptions.CommandException;
 import seedu.us.among.logic.endpoint.exceptions.RequestException;
 import seedu.us.among.model.EndpointList;
 import seedu.us.among.model.Model;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
 import seedu.us.among.model.endpoint.Endpoint;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
 import seedu.us.among.testutil.EditEndpointDescriptorBuilder;
 
 /**
@@ -116,7 +117,7 @@ public class CommandTestUtil {
 
         Endpoint endpoint = model.getFilteredEndpointList().get(targetIndex.getZeroBased());
         final String[] splitTags = endpoint.getTags().toString().split("\\s+");
-        model.updateFilteredEndpointList(new NameContainsKeywordsPredicate(Arrays.asList(splitTags[0])));
+        model.updateFilteredEndpointList(new EndPointContainsKeywordsPredicate(Arrays.asList(splitTags[0])));
 
         assertEquals(1, model.getFilteredEndpointList().size());
     }

--- a/src/test/java/seedu/us/among/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.us.among.model.Model;
 import seedu.us.among.model.ModelManager;
 import seedu.us.among.model.UserPrefs;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for
@@ -30,9 +30,9 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(
+        EndPointContainsKeywordsPredicate firstPredicate = new EndPointContainsKeywordsPredicate(
                 Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(
+        EndPointContainsKeywordsPredicate secondPredicate = new EndPointContainsKeywordsPredicate(
                 Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
@@ -58,7 +58,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noEndpointFound() {
         String expectedMessage = String.format(MESSAGE_ENDPOINTS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        EndPointContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredEndpointList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -68,7 +68,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multipleEndpointsFound() {
         String expectedMessage = String.format(MESSAGE_ENDPOINTS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("put head options");
+        EndPointContainsKeywordsPredicate predicate = preparePredicate("put head options");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredEndpointList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -78,7 +78,7 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private EndPointContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new EndPointContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/us/among/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.us.among.logic.commands.FindCommand;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -24,7 +24,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand = new FindCommand(
-                new NameContainsKeywordsPredicate(Arrays.asList("GET", "POST")));
+                new EndPointContainsKeywordsPredicate(Arrays.asList("GET", "POST")));
         assertParseSuccess(parser, "GET POST", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/us/among/logic/parser/ImposterParserTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/ImposterParserTest.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
@@ -25,8 +26,8 @@ import seedu.us.among.logic.commands.HelpCommand;
 import seedu.us.among.logic.commands.ListCommand;
 import seedu.us.among.logic.commands.RemoveCommand;
 import seedu.us.among.logic.parser.exceptions.ParseException;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
 import seedu.us.among.model.endpoint.Endpoint;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
 import seedu.us.among.testutil.EditEndpointDescriptorBuilder;
 import seedu.us.among.testutil.EndpointBuilder;
 import seedu.us.among.testutil.EndpointUtil;
@@ -75,7 +76,7 @@ public class ImposterParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new EndPointContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/model/ModelManagerTest.java
+++ b/src/test/java/seedu/us/among/model/ModelManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import seedu.us.among.commons.core.GuiSettings;
-import seedu.us.among.model.endpoint.NameContainsKeywordsPredicate;
+import seedu.us.among.model.endpoint.EndPointContainsKeywordsPredicate;
 import seedu.us.among.testutil.EndpointListBuilder;
 
 public class ModelManagerTest {
@@ -119,7 +119,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = GET.getMethod().methodName.split("\\s+");
-        modelManager.updateFilteredEndpointList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredEndpointList(new EndPointContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(endpointList, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/us/among/testutil/EndpointUtil.java
+++ b/src/test/java/seedu/us/among/testutil/EndpointUtil.java
@@ -43,16 +43,25 @@ public class EndpointUtil {
      */
     public static String getEditEndpointDescriptorDetails(EditCommand.EditEndpointDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getMethod().ifPresent(name -> sb.append(PREFIX_METHOD).append(name.methodName).append(" "));
-        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
-        descriptor.getData().ifPresent(data -> sb.append(PREFIX_DATA).append(data.value).append(" "));
+        descriptor.getMethod().ifPresent(name -> sb.append(PREFIX_METHOD)
+                .append(" ")
+                .append(name.methodName)
+                .append(" "));
+        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS)
+                .append(" ")
+                .append(address.value)
+                .append(" "));
+        descriptor.getData().ifPresent(data -> sb.append(PREFIX_DATA)
+                .append(" ")
+                .append(data.value)
+                .append(" "));
 
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(" ");
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(" ").append(s.tagName).append(" "));
             }
         }
         if (descriptor.getHeaders().isPresent()) {
@@ -60,7 +69,7 @@ public class EndpointUtil {
             if (headers.isEmpty()) {
                 sb.append(PREFIX_HEADER);
             } else {
-                headers.forEach(s -> sb.append(PREFIX_HEADER).append(s.headerName).append(" "));
+                headers.forEach(s -> sb.append(PREFIX_HEADER).append(" ").append(s.headerName).append(" "));
             }
         }
         return sb.toString();


### PR DESCRIPTION
Fixes #217 

Find command can now take in arguments such as -x -u -t ... 
Find command can now take in multiple keywords. 

Examples: 
`find -x METHOD` or find `-x METHOD METHOD` (in this case, will find both keywords)
`find -u URL`
and so on... 


