### PR TITLE
Adjust ListCommand message

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/AddCommand.java
@@ -18,8 +18,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_API_EXAMPLE_1 = "1. "
-            + COMMAND_WORD + " "
+    public static final String MESSAGE_API_EXAMPLE_1 = COMMAND_WORD + " "
             + PREFIX_METHOD + " get "
             + PREFIX_ADDRESS + " http://localhost:3000/ "
             + PREFIX_DATA + " {\"some\": \"data\"} "
@@ -28,10 +27,9 @@ public class AddCommand extends Command {
             + PREFIX_TAG + " local "
             + PREFIX_TAG + " data\n";
 
-    public static final String MESSAGE_API_EXAMPLE_2 = "2. "
-            + COMMAND_WORD + " "
+    public static final String MESSAGE_API_EXAMPLE_2 = COMMAND_WORD + " "
             + PREFIX_METHOD + " get "
-            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature ";
+            + PREFIX_ADDRESS + " https://api.data.gov.sg/v1/environment/air-temperature";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an API endpoint to the API endpoint list.\n"

--- a/src/main/java/seedu/us/among/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ListCommand.java
@@ -11,13 +11,29 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all API endpoints";
+    private static final String MESSAGE_SUCCESS = "Listed all saved API endpoints on the left-hand-side panel.\n";
+
+    private static final String MESSAGE_FILLED_LIST = "Want to see the details of an API endpoint?\n"
+            + "Use the show command with the index of an endpoint!\n"
+            + "Example (to show the details of the first endpoint):\n"
+            + "show 1";
+
+    private static final String MESSAGE_EMPTY_LIST = "Want to add endpoints to fill your empty list?\n"
+            + "Use the add command with the details of an endpoint!\n"
+            + "Example (adding a sample endpoint):\n"
+            + "add -x GET -u https://api.data.gov.sg/v1/environment/air-temperature";
+
+    public static final String MESSAGE_SUCCESS_WITH_FILLED_LIST = MESSAGE_SUCCESS + MESSAGE_FILLED_LIST;
+
+    public static final String MESSAGE_SUCCESS_WITH_EMPTY_LIST = MESSAGE_SUCCESS + MESSAGE_EMPTY_LIST;
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredEndpointList(Model.PREDICATE_SHOW_ALL_ENDPOINTS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return model.isEndpointListEmpty() ? new CommandResult(MESSAGE_SUCCESS_WITH_EMPTY_LIST)
+                :
+                new CommandResult(MESSAGE_SUCCESS_WITH_FILLED_LIST);
     }
 }

--- a/src/main/java/seedu/us/among/model/EndpointList.java
+++ b/src/main/java/seedu/us/among/model/EndpointList.java
@@ -118,4 +118,8 @@ public class EndpointList implements ReadOnlyEndpointList {
     public int hashCode() {
         return endpoints.hashCode();
     }
+
+    public boolean isEmpty() {
+        return endpoints.isEmpty();
+    }
 }

--- a/src/main/java/seedu/us/among/model/Model.java
+++ b/src/main/java/seedu/us/among/model/Model.java
@@ -52,6 +52,9 @@ public interface Model {
     /** Returns the EndpointList */
     ReadOnlyEndpointList getEndpointList();
 
+    /** Returns true if there is no endpoints in EndpointList */
+    boolean isEndpointListEmpty();
+
     /**
      * Returns true if a endpoint with the same identity as {@code endpoint} exists in the API endpoint list.
      */

--- a/src/main/java/seedu/us/among/model/ModelManager.java
+++ b/src/main/java/seedu/us/among/model/ModelManager.java
@@ -112,6 +112,11 @@ public class ModelManager implements Model {
         endpointList.setEndpoint(target, editedEndpoint);
     }
 
+    @Override
+    public boolean isEndpointListEmpty() {
+        return endpointList.isEmpty();
+    }
+
     //=========== Filtered Endpoint List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/us/among/model/endpoint/UniqueEndpointList.java
+++ b/src/main/java/seedu/us/among/model/endpoint/UniqueEndpointList.java
@@ -12,9 +12,9 @@ import seedu.us.among.model.endpoint.exceptions.DuplicateApiEndpointException;
 import seedu.us.among.model.endpoint.exceptions.EndpointNotFoundException;
 
 /**
- * A list of persons that enforces uniqueness between its elements and does not allow nulls.
- * A endpoint is considered unique by comparing using {@code Endpoint#isSamePerson(Endpoint)}. As such, adding and
- * updating of persons uses Endpoint#isSamePerson(Endpoint) for equality so as to ensure that the endpoint being
+ * A list of endpoints that enforces uniqueness between its elements and does not allow nulls.
+ * A endpoint is considered unique by comparing using {@code Endpoint#isSameEndpoint(Endpoint)}. As such, adding and
+ * updating of endpoints uses Endpoint#isSameEndpoint(Endpoint) for equality so as to ensure that the endpoint being
  * added or updated is unique in terms of identity in the UniqueEndpointList. However, the removal of a endpoint
  * uses Endpoint#equals(Object) so as to ensure that the endpoint with exactly the same fields will be removed.
  *
@@ -95,6 +95,14 @@ public class UniqueEndpointList implements Iterable<Endpoint> {
         }
 
         internalList.setAll(endpoints);
+    }
+
+    /**
+     * Returns true if there are no endpoints in the list.
+     * Useful for the list command to deal with the case of no endpoints saved.
+     */
+    public boolean isEmpty() {
+        return internalList.isEmpty();
     }
 
     /**

--- a/src/main/java/seedu/us/among/ui/EndpointListPanel.java
+++ b/src/main/java/seedu/us/among/ui/EndpointListPanel.java
@@ -19,21 +19,21 @@ public class EndpointListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(EndpointListPanel.class);
 
     @FXML
-    private ListView<Endpoint> personListView;
+    private ListView<Endpoint> endpointListView;
 
     /**
      * Creates a {@code EndpointListPanel} with the given {@code ObservableList}.
      */
     public EndpointListPanel(ObservableList<Endpoint> endpointList) {
         super(FXML);
-        personListView.setItems(endpointList);
-        personListView.setCellFactory(listView -> new PersonListViewCell());
+        endpointListView.setItems(endpointList);
+        endpointListView.setCellFactory(listView -> new EndpointListViewCell());
     }
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Endpoint} using a {@code EndpointCard}.
      */
-    class PersonListViewCell extends ListCell<Endpoint> {
+    class EndpointListViewCell extends ListCell<Endpoint> {
         @Override
         protected void updateItem(Endpoint endpoint, boolean empty) {
             super.updateItem(endpoint, empty);

--- a/src/main/resources/view/EndpointListPanel.fxml
+++ b/src/main/resources/view/EndpointListPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="endpointListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/us/among/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/us/among/logic/LogicManagerTest.java
@@ -66,7 +66,8 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+        assertCommandSuccess(listCommand,
+                ListCommand.MESSAGE_SUCCESS_WITH_EMPTY_LIST, model);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/AddCommandTest.java
@@ -120,6 +120,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isEndpointListEmpty() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ReadOnlyEndpointList getEndpointList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/us/among/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/ListCommandTest.java
@@ -1,18 +1,18 @@
 package seedu.us.among.logic.commands;
 
 import static seedu.us.among.logic.commands.CommandTestUtil.assertCommandSuccess;
-// import static seedu.us.among.logic.commands.CommandTestUtil.showEndpointAtIndex;
 import static seedu.us.among.logic.commands.CommandTestUtil.showEndpointAtIndex;
 import static seedu.us.among.testutil.TypicalEndpoints.getTypicalEndpointList;
 import static seedu.us.among.testutil.TypicalIndexes.INDEX_FIRST_ENDPOINT;
-// import static seedu.us.among.testutil.TypicalIndexes.INDEX_FIRST_ENDPOINT;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.us.among.model.EndpointList;
 import seedu.us.among.model.Model;
 import seedu.us.among.model.ModelManager;
 import seedu.us.among.model.UserPrefs;
+import seedu.us.among.testutil.TypicalEndpoints;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
@@ -21,21 +21,33 @@ public class ListCommandTest {
 
     private Model model;
     private Model expectedModel;
+    private Model emptyModel;
 
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalEndpointList(), new UserPrefs());
         expectedModel = new ModelManager(model.getEndpointList(), new UserPrefs());
+        emptyModel = new ModelManager(TypicalEndpoints.getTypicalEndpointList(), new UserPrefs());
+        emptyModel.setEndpointList(new EndpointList());
     }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                ListCommand.MESSAGE_SUCCESS_WITH_FILLED_LIST, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showEndpointAtIndex(model, INDEX_FIRST_ENDPOINT);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                ListCommand.MESSAGE_SUCCESS_WITH_FILLED_LIST, expectedModel);
     }
+
+    @Test
+    public void execute_listIsEmpty_displayEmptyMessage() {
+        assertCommandSuccess(new ListCommand(), emptyModel,
+                ListCommand.MESSAGE_SUCCESS_WITH_EMPTY_LIST, emptyModel);
+    }
+
 }


### PR DESCRIPTION
ListCommand result is not helpful as it simply says all endpoints
listed. It does not account for the cases where there is no endpoints
saved.

Let's adjust the result output to prompt user to use show command if
there are endpoints saved, or use add command to add new endpoints.

This will make the result clearer to users.

I have also fixed the minor typos and clean up the numbering in
addCommand in order to allow users to easily copy paste the examples.
Some test cases are also fixed along the way.

screenshots:
![image](https://user-images.githubusercontent.com/41845017/111856760-f6c9f700-8967-11eb-944f-35dc6f20bf93.png)
![image](https://user-images.githubusercontent.com/41845017/111856770-ffbac880-8967-11eb-83ad-6a454660d671.png)

Fixes: #298 
Fixes: #163 