### PR TITLE
UI: Make headers look like tags

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -361,6 +361,20 @@
     -fx-font-size: 11;
 }
 
+#headers {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#headers .label {
+    -fx-text-fill: black;
+    -fx-background-color: #FFA100;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
 #responseMeta {
     -fx-hgap: 7;
     -fx-vgap: 3;

--- a/src/main/resources/view/EndpointListCard.fxml
+++ b/src/main/resources/view/EndpointListCard.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" spacing="1">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>

--- a/src/main/resources/view/ImposterTheme.css
+++ b/src/main/resources/view/ImposterTheme.css
@@ -363,6 +363,20 @@
     -fx-font-size: 11;
 }
 
+#headers {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#headers .label {
+    -fx-text-fill: rgb(255, 255, 255);
+    -fx-background-color: #0092FF;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
 #responseMeta {
     -fx-hgap: 7;
     -fx-vgap: 3;

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -356,6 +356,20 @@
     -fx-font-size: 11;
 }
 
+#headers {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#headers .label {
+    -fx-text-fill: rgb(0, 0, 0);
+    -fx-background-color: #FFA100;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
 #responseMeta {
     -fx-hgap: 7;
     -fx-vgap: 3;


### PR DESCRIPTION
Addresses #255.
Have made headers cyan in Imposter theme and orange in others instead of the initially proposed green.