### PR TITLE
Command fixed another small bug with find

### DIFF
--- a/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
@@ -44,9 +44,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] nameKeywords;
 
         //Case 1: If no prefix present (general search)
-        if (!argMultimap.arePrefixesPresent(PREFIX_METHOD, PREFIX_ADDRESS, PREFIX_DATA, PREFIX_HEADER, PREFIX_TAG)) {
+        if (!argMultimap.arePrefixesPresent
+                (PREFIX_METHOD, PREFIX_ADDRESS, PREFIX_DATA, PREFIX_HEADER, PREFIX_TAG)) {
             nameKeywords = getNameKeywords(args);
-            System.out.println("wiowajdoawkd" + nameKeywords.toString());
             return new FindCommand(new EndPointContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
 
@@ -82,7 +82,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             nameKeywords = getNameKeywords(input);
             predicateList.add(new TagsContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
-        System.out.println("what the fuck" + predicateList.toString());
+
         return new FindCommand(predicateList.stream().reduce(x -> true, Predicate::and));
     }
 

--- a/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/FindCommandParser.java
@@ -44,8 +44,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] nameKeywords;
 
         //Case 1: If no prefix present (general search)
-        if (argMultimap.arePrefixesPresent()) {
+        if (!argMultimap.arePrefixesPresent(PREFIX_METHOD, PREFIX_ADDRESS, PREFIX_DATA, PREFIX_HEADER, PREFIX_TAG)) {
             nameKeywords = getNameKeywords(args);
+            System.out.println("wiowajdoawkd" + nameKeywords.toString());
             return new FindCommand(new EndPointContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
 
@@ -81,7 +82,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             nameKeywords = getNameKeywords(input);
             predicateList.add(new TagsContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
-
+        System.out.println("what the fuck" + predicateList.toString());
         return new FindCommand(predicateList.stream().reduce(x -> true, Predicate::and));
     }
 


### PR DESCRIPTION
How find should work: 

1. find -x get -x post (search: post) (in -x field only)
2. find get post (search: either get or post) (in all fields)
3. find -x get post (search: get in -x field) or (post in all fields)
4. find -x get -t cat (search: get in -x field and cat in -t field) (both must be present to show up)