### PR TITLE
Refactor isSameEndpoint method

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/EditCommand.java
@@ -114,7 +114,7 @@ public class EditCommand extends Command {
         Endpoint endpointToEdit = lastShownList.get(index.getZeroBased());
         Endpoint editedEndpoint = createEditedEndpoint(endpointToEdit, editEndpointDescriptor);
 
-        if (!endpointToEdit.isSameEndpoint(editedEndpoint) && model.hasEndpoint(editedEndpoint)) {
+        if (!endpointToEdit.equals(editedEndpoint) && model.hasEndpoint(editedEndpoint)) {
             throw new CommandException(MESSAGE_DUPLICATE_ENDPOINT);
         }
 

--- a/src/main/java/seedu/us/among/model/endpoint/Endpoint.java
+++ b/src/main/java/seedu/us/among/model/endpoint/Endpoint.java
@@ -145,21 +145,7 @@ public class Endpoint {
     }
 
     /**
-     * Returns true if both endpoint are the same.
-     */
-    public boolean isSameEndpoint(Endpoint otherEndpoint) {
-        if (otherEndpoint == this) {
-            return true;
-        } else if (otherEndpoint == null) {
-            return false;
-        } else {
-            return otherEndpoint.equals(this);
-        }
-    }
-
-    /**
-     * Returns true if both methods have the same identity and data fields. This
-     * defines a stronger notion of equality between two methods.
+     * Returns true if both methods have the same identity and data fields.
      */
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/us/among/model/endpoint/UniqueEndpointList.java
+++ b/src/main/java/seedu/us/among/model/endpoint/UniqueEndpointList.java
@@ -13,14 +13,12 @@ import seedu.us.among.model.endpoint.exceptions.EndpointNotFoundException;
 
 /**
  * A list of endpoints that enforces uniqueness between its elements and does not allow nulls.
- * A endpoint is considered unique by comparing using {@code Endpoint#isSameEndpoint(Endpoint)}. As such, adding and
- * updating of endpoints uses Endpoint#isSameEndpoint(Endpoint) for equality so as to ensure that the endpoint being
- * added or updated is unique in terms of identity in the UniqueEndpointList. However, the removal of a endpoint
+ * A endpoint is considered unique by comparing using {@code Endpoint#equals(Endpoint)} for
+ * equality so as to ensure that the endpoint being
+ * added or updated is unique in terms of identity in the UniqueEndpointList. The removal of a endpoint
  * uses Endpoint#equals(Object) so as to ensure that the endpoint with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
- *
- * @see Endpoint#isSameEndpoint(Endpoint)
  */
 public class UniqueEndpointList implements Iterable<Endpoint> {
 
@@ -33,7 +31,7 @@ public class UniqueEndpointList implements Iterable<Endpoint> {
      */
     public boolean contains(Endpoint toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameEndpoint);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**
@@ -61,7 +59,7 @@ public class UniqueEndpointList implements Iterable<Endpoint> {
             throw new EndpointNotFoundException();
         }
 
-        if (!target.isSameEndpoint(editedEndpoint) && contains(editedEndpoint)) {
+        if (!target.equals(editedEndpoint) && contains(editedEndpoint)) {
             throw new DuplicateApiEndpointException();
         }
 
@@ -135,7 +133,7 @@ public class UniqueEndpointList implements Iterable<Endpoint> {
     private boolean endpointsAreUnique(List<Endpoint> endpoints) {
         for (int i = 0; i < endpoints.size() - 1; i++) {
             for (int j = i + 1; j < endpoints.size(); j++) {
-                if (endpoints.get(i).isSameEndpoint(endpoints.get(j))) {
+                if (endpoints.get(i).equals(endpoints.get(j))) {
                     return false;
                 }
             }

--- a/src/test/java/seedu/us/among/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/AddCommandTest.java
@@ -169,7 +169,7 @@ public class AddCommandTest {
         @Override
         public boolean hasEndpoint(Endpoint endpoint) {
             requireNonNull(endpoint);
-            return this.endpoint.isSameEndpoint(endpoint);
+            return this.endpoint.equals(endpoint);
         }
     }
 
@@ -182,7 +182,7 @@ public class AddCommandTest {
         @Override
         public boolean hasEndpoint(Endpoint endpoint) {
             requireNonNull(endpoint);
-            return endpointsAdded.stream().anyMatch(endpoint::isSameEndpoint);
+            return endpointsAdded.stream().anyMatch(endpoint::equals);
         }
 
         @Override

--- a/src/test/java/seedu/us/among/model/endpoint/EndpointTest.java
+++ b/src/test/java/seedu/us/among/model/endpoint/EndpointTest.java
@@ -30,27 +30,27 @@ public class EndpointTest {
     @Test
     public void isSameMethod() {
         // same object -> returns true
-        assertTrue(GET.isSameEndpoint(GET));
+        assertTrue(GET.equals(GET));
 
         // null -> returns false
-        assertFalse(GET.isSameEndpoint(null));
+        assertFalse(GET.equals(null));
 
         // same method and address, all other attributes different -> returns false
         Endpoint editedGet = new EndpointBuilder(GET).withAddress(VALID_ADDRESS_RANDOM).withTags(VALID_TAG_COOL)
                 .build();
-        assertFalse(GET.isSameEndpoint(editedGet));
+        assertFalse(GET.equals(editedGet));
 
         // same name, all other attributes different -> returns false
         editedGet = new EndpointBuilder(GET).withAddress(VALID_ADDRESS_FACT).withTags(VALID_TAG_CAT).build();
-        assertFalse(GET.isSameEndpoint(editedGet));
+        assertFalse(GET.equals(editedGet));
 
         // different name, all other attributes same -> returns false
         editedGet = new EndpointBuilder(GET).withMethod(VALID_METHOD_POST).build();
-        assertFalse(GET.isSameEndpoint(editedGet));
+        assertFalse(GET.equals(editedGet));
 
         // name differs in case, all other attributes same -> returns false
         Endpoint editedPost = new EndpointBuilder(POST).withMethod(VALID_METHOD_GET.toLowerCase()).build();
-        assertFalse(POST.isSameEndpoint(editedPost));
+        assertFalse(POST.equals(editedPost));
 
         // to-do add more tests for this
 


### PR DESCRIPTION
Removes the `isSameEndpoint` method as it behaves the same as `equals`
Fixes #326 