### PR TITLE
Refactor: move exception handling for request into EndpointCaller

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -1,31 +1,11 @@
 package seedu.us.among.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.us.among.commons.core.Messages.MESSAGE_CALL_CANCELLED;
-import static seedu.us.among.commons.core.Messages.MESSAGE_CONNECTION_ERROR;
-import static seedu.us.among.commons.core.Messages.MESSAGE_GENERAL_ERROR;
-import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_JSON;
-import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_HOST;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_DATA;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_HEADER;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_METHOD;
 
-import java.io.InterruptedIOException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
-import java.rmi.ConnectException;
-import java.util.logging.Logger;
-import javax.net.ssl.SSLException;
-
-import org.apache.http.NoHttpResponseException;
-import org.apache.http.client.ClientProtocolException;
-
-import com.fasterxml.jackson.core.JsonParseException;
-
-import seedu.us.among.commons.core.LogsCenter;
-import seedu.us.among.commons.util.StringUtil;
 import seedu.us.among.logic.commands.exceptions.CommandException;
 import seedu.us.among.logic.request.EndpointCaller;
 import seedu.us.among.logic.request.exceptions.AbortRequestException;
@@ -73,8 +53,6 @@ public class RunCommand extends Command {
             + MESSAGE_API_EXAMPLE_2 + "\n"
             + QUICK_RUN_COMMAND_SYNTAX;
 
-    private static final Logger logger = LogsCenter.getLogger(RunCommand.class);
-
     private final Endpoint toRun;
 
     /**
@@ -89,26 +67,8 @@ public class RunCommand extends Command {
     public CommandResult execute(Model model) throws CommandException, RequestException, AbortRequestException {
         requireNonNull(model);
 
-        EndpointCaller epc = new EndpointCaller(toRun);
-        Response response;
-        try {
-            response = epc.callEndpoint();
-        } catch (UnknownHostException | IllegalArgumentException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_UNKNOWN_HOST);
-        } catch (ClientProtocolException | SocketTimeoutException | SocketException | ConnectException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_CONNECTION_ERROR);
-        } catch (JsonParseException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_INVALID_JSON);
-        } catch (IllegalStateException | SSLException | NoHttpResponseException | InterruptedIOException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new AbortRequestException(MESSAGE_CALL_CANCELLED);
-        } catch (Exception e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_GENERAL_ERROR);
-        }
+        EndpointCaller endpointCaller = new EndpointCaller(toRun);
+        Response response = endpointCaller.callEndpoint();
 
         Endpoint endpointWithResponse = new Endpoint(toRun, response);
         return new CommandResult(endpointWithResponse.getResponseEntity(),

--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -1,30 +1,13 @@
 package seedu.us.among.logic.commands;
 
-import static seedu.us.among.commons.core.Messages.MESSAGE_CALL_CANCELLED;
-import static seedu.us.among.commons.core.Messages.MESSAGE_CONNECTION_ERROR;
-import static seedu.us.among.commons.core.Messages.MESSAGE_GENERAL_ERROR;
-import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_JSON;
-import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_HOST;
 import static seedu.us.among.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.io.InterruptedIOException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
-import java.rmi.ConnectException;
 import java.util.List;
 import java.util.logging.Logger;
-import javax.net.ssl.SSLException;
-
-import org.apache.http.NoHttpResponseException;
-import org.apache.http.client.ClientProtocolException;
-
-import com.fasterxml.jackson.core.JsonParseException;
 
 import seedu.us.among.commons.core.LogsCenter;
 import seedu.us.among.commons.core.Messages;
 import seedu.us.among.commons.core.index.Index;
-import seedu.us.among.commons.util.StringUtil;
 import seedu.us.among.logic.commands.exceptions.CommandException;
 import seedu.us.among.logic.request.EndpointCaller;
 import seedu.us.among.logic.request.exceptions.AbortRequestException;
@@ -68,28 +51,8 @@ public class SendCommand extends Command {
         }
 
         Endpoint endpointToSend = lastShownList.get(index.getZeroBased());
-        EndpointCaller epc = new EndpointCaller(endpointToSend);
-        Response response;
-
-        //to-do Tan Jin verify again all errors caught here due to API calls
-        try {
-            response = epc.callEndpoint();
-        } catch (UnknownHostException | IllegalArgumentException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_UNKNOWN_HOST);
-        } catch (ClientProtocolException | SocketTimeoutException | SocketException | ConnectException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_CONNECTION_ERROR);
-        } catch (JsonParseException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_INVALID_JSON);
-        } catch (IllegalStateException | SSLException | NoHttpResponseException | InterruptedIOException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new AbortRequestException(MESSAGE_CALL_CANCELLED);
-        } catch (Exception e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_GENERAL_ERROR);
-        }
+        EndpointCaller endpointCaller = new EndpointCaller(endpointToSend);
+        Response response = endpointCaller.callEndpoint();
 
         Endpoint endpointWithResponse = new Endpoint(endpointToSend, response);
         model.setEndpoint(endpointToSend, endpointWithResponse);

--- a/src/main/java/seedu/us/among/logic/request/EndpointCaller.java
+++ b/src/main/java/seedu/us/among/logic/request/EndpointCaller.java
@@ -1,7 +1,27 @@
 package seedu.us.among.logic.request;
 
-import java.io.IOException;
+import static seedu.us.among.commons.core.Messages.MESSAGE_CALL_CANCELLED;
+import static seedu.us.among.commons.core.Messages.MESSAGE_CONNECTION_ERROR;
+import static seedu.us.among.commons.core.Messages.MESSAGE_GENERAL_ERROR;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_JSON;
+import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_HOST;
 
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.logging.Logger;
+import javax.net.ssl.SSLException;
+
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.ClientProtocolException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+import seedu.us.among.commons.core.LogsCenter;
+import seedu.us.among.commons.util.StringUtil;
+import seedu.us.among.logic.request.exceptions.AbortRequestException;
 import seedu.us.among.logic.request.exceptions.RequestException;
 import seedu.us.among.model.endpoint.Endpoint;
 import seedu.us.among.model.endpoint.MethodType;
@@ -11,6 +31,8 @@ import seedu.us.among.model.endpoint.Response;
  * Contains the logic for making API calls.
  */
 public class EndpointCaller {
+    private static final Logger logger = LogsCenter.getLogger(EndpointCaller.class);
+
     private final Endpoint endpointToSend;
 
     /**
@@ -23,41 +45,61 @@ public class EndpointCaller {
     }
 
     /**
-     * Sends the appropriate request based on attributes provided in EndpointCaller.
+     * Calls the endpoint based on attributes provided in EndpointCaller.
      *
      * @return response of API call
      */
-    public Response callEndpoint() throws IOException, RequestException {
+    public Response callEndpoint() throws RequestException, AbortRequestException {
 
-        Response response = new Response();
-        MethodType requestMethod = this.endpointToSend.getMethodType();
+        Response response;
 
-        switch (requestMethod) {
-        case GET:
-            response = new GetRequest(endpointToSend).send();
-            break;
-        case POST:
-            response = new PostRequest(endpointToSend).send();
-            break;
-        case PUT:
-            response = new PutRequest(endpointToSend).send();
-            break;
-        case DELETE:
-            response = new DeleteRequest(endpointToSend).send();
-            break;
-        case HEAD:
-            response = new HeadRequest(endpointToSend).send();
-            break;
-        case OPTIONS:
-            response = new OptionsRequest(endpointToSend).send();
-            break;
-        case PATCH:
-            response = new PatchRequest(endpointToSend).send();
-            break;
-        default:
-            break;
+        //to-do Tan Jin verify again all errors caught here due to API calls
+        try {
+            response = sendRequest();
+        } catch (UnknownHostException e) {
+            logger.warning(StringUtil.getDetails(e));
+            throw new RequestException(MESSAGE_UNKNOWN_HOST);
+        } catch (ClientProtocolException | SocketTimeoutException | SocketException e) {
+            logger.warning(StringUtil.getDetails(e));
+            throw new RequestException(MESSAGE_CONNECTION_ERROR);
+        } catch (JsonParseException e) {
+            logger.warning(StringUtil.getDetails(e));
+            throw new RequestException(MESSAGE_INVALID_JSON);
+        } catch (IllegalStateException | SSLException | NoHttpResponseException | InterruptedIOException e) {
+            logger.warning(StringUtil.getDetails(e));
+            throw new AbortRequestException(MESSAGE_CALL_CANCELLED);
+        } catch (IOException e) {
+            logger.warning(StringUtil.getDetails(e));
+            throw new RequestException(MESSAGE_GENERAL_ERROR);
         }
 
         return response;
+    }
+
+    /**
+     * Matches and sends the request based on type of method specified.
+     *
+     * @return response of API call
+     */
+    public Response sendRequest() throws IOException, RequestException {
+        MethodType requestMethod = this.endpointToSend.getMethodType();
+        switch (requestMethod) {
+        case GET:
+            return new GetRequest(endpointToSend).send();
+        case POST:
+            return new PostRequest(endpointToSend).send();
+        case PUT:
+            return new PutRequest(endpointToSend).send();
+        case DELETE:
+            return new DeleteRequest(endpointToSend).send();
+        case HEAD:
+            return new HeadRequest(endpointToSend).send();
+        case OPTIONS:
+            return new OptionsRequest(endpointToSend).send();
+        case PATCH:
+            return new PatchRequest(endpointToSend).send();
+        default:
+            return new Response();
+        }
     }
 }


### PR DESCRIPTION
Move exception handling for request into `EndpointCaller` to reduce repeated codes in `Send` and `Run`.

Resolves #340 