### PR TITLE
Chore: enable assertions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,4 +76,9 @@ shadowJar {
     archiveName = 'imPoster.jar'
 }
 
+run {
+    standardInput = System.in
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
As described in title.

Closes #361 