### PR TITLE
Remove a space in front of Response body wording

### DIFF
--- a/src/main/java/seedu/us/among/ui/ResultDisplay.java
+++ b/src/main/java/seedu/us/among/ui/ResultDisplay.java
@@ -168,7 +168,7 @@ public class ResultDisplay extends UiPart<Region> {
         requireNonNull(feedbackToUser);
 
         String textFeedback = String.format(
-                "Endpoint:\n============\n\n%s\n\n Response Body:\n============\n\n%s",
+                "Endpoint:\n============\n\n%s\n\nResponse Body:\n============\n\n%s",
                         endpoint.getAddress(), feedbackToUser);
 
         if (!Platform.isFxApplicationThread()) {


### PR DESCRIPTION
There is a weird space before the word `Response`
Fixes: #396 