### PR TITLE
UI: Fix wrong theme gifs in new material theme

### DIFF
--- a/src/main/java/seedu/us/among/ui/ResultDisplay.java
+++ b/src/main/java/seedu/us/among/ui/ResultDisplay.java
@@ -93,7 +93,7 @@ public class ResultDisplay extends UiPart<Region> {
     }
 
     public void setErrorGifType(String theme) {
-        if (theme.equalsIgnoreCase("light")) {
+        if (theme.equalsIgnoreCase("light") || theme.equalsIgnoreCase("material")) {
             this.errorGifType = "error-black.gif";
         } else {
             this.errorGifType = "error-white.gif";
@@ -101,7 +101,7 @@ public class ResultDisplay extends UiPart<Region> {
     }
 
     public void setSpinnerGifType(String theme) {
-        if (theme.equalsIgnoreCase("light")) {
+        if (theme.equalsIgnoreCase("light") || theme.equalsIgnoreCase("material")) {
             this.loadingSpinnerPlaceholder.setImage(loadingSpinnerForLight);
         } else {
             this.loadingSpinnerPlaceholder.setImage(loadingSpinnerForDark);


### PR DESCRIPTION
The new material theme introduced in #404 reused the gifs with white text meant for dark backgrounds; this PR is meant to change them to the ones with black text.