### PR TITLE
Refactor CommandResult constructors

### DIFF
--- a/src/main/java/seedu/us/among/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/us/among/logic/commands/CommandResult.java
@@ -31,53 +31,70 @@ public class CommandResult {
     /** API endpoint to be consumed by the UI for displaying response. */
     private final Endpoint endpoint;
 
-
     /**
      * Constructs a {@code CommandResult} with the specified fields.
+     * This is the primary private constructor of CommandResult to be used in other factor constructors.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean isList) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
-        this.isApiResponse = false;
-        this.isList = isList;
-        this.toggleTheme = null;
-        this.endpoint = null;
-    }
-
-    /**
-     * Constructs a {@code CommandResult} with the specified fields, including the newly added isApiResponse.
-     */
-    public CommandResult(String feedbackToUser, Endpoint endpoint, boolean showHelp, boolean exit,
-                         boolean isApiResponse) {
+    private CommandResult(String feedbackToUser, String toggleTheme, Endpoint endpoint,
+                          boolean showHelp, boolean exit, boolean isList,
+                          boolean isApiResponse) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.isApiResponse = isApiResponse;
-        this.isList = false;
-        this.toggleTheme = null;
+        this.isList = isList;
+        this.toggleTheme = toggleTheme;
         this.endpoint = endpoint;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * and other fields set to their default value. This is the convenient constructor for commands with a string
+     * feedback.
+     */
+    public CommandResult(String feedbackToUser) {
+        this(feedbackToUser, null,
+                null, false, false, false, false);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified fields. This is the constructor for request related
+     * commands such send & run.
+     */
+    public CommandResult(String feedbackToUser, Endpoint endpoint) {
+        this(feedbackToUser, null, endpoint,
+                false, false, false, true);
     }
 
     /**
      * Constructs a {@code CommandResult} with the specified fields, including the newly added theme to toggle.
      */
     public CommandResult(String feedbackToUser, String themeToToggle) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = false;
-        this.exit = false;
-        this.isApiResponse = false;
-        this.isList = false;
-        this.toggleTheme = themeToToggle;
-        this.endpoint = null;
+        this(feedbackToUser, themeToToggle, null, false, false, false, false);
     }
 
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value.
+     * Constructs a {@code CommandResult} for exit command.
      */
-    public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false);
+    public static CommandResult exitCommandResult(String feedbackToUser) {
+        return new CommandResult(feedbackToUser, null, null,
+                false, true, false, false);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} for help command.
+     */
+    public static CommandResult helpCommandResult(String feedbackToUser) {
+        return new CommandResult(feedbackToUser, null, null,
+                true, false, false, false);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} for list command.
+     */
+    public static CommandResult listCommandResult(String feedbackToUser) {
+        return new CommandResult(feedbackToUser, null, null,
+                false, false, true, false);
     }
 
     public String getFeedbackToUser() {

--- a/src/main/java/seedu/us/among/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ExitCommand.java
@@ -1,5 +1,7 @@
 package seedu.us.among.logic.commands;
 
+import static seedu.us.among.logic.commands.CommandResult.exitCommandResult;
+
 import seedu.us.among.model.Model;
 
 /**
@@ -7,18 +9,13 @@ import seedu.us.among.model.Model;
  */
 public class ExitCommand extends Command {
 
-    public static final boolean SHOW_HELP = false;
-    public static final boolean IS_EXIT = true;
-    public static final boolean IS_LIST = false;
-
-
     public static final String COMMAND_WORD = "exit";
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting imPoster as requested ...";
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, SHOW_HELP, IS_EXIT, IS_LIST);
+        return exitCommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
     }
 
 }

--- a/src/main/java/seedu/us/among/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/HelpCommand.java
@@ -7,10 +7,6 @@ import seedu.us.among.model.Model;
  */
 public class HelpCommand extends Command {
 
-    public static final boolean SHOW_HELP = true;
-    public static final boolean IS_EXIT = false;
-    public static final boolean IS_LIST = false;
-
     public static final String COMMAND_WORD = "help";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
@@ -20,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, SHOW_HELP, IS_EXIT, IS_LIST);
+        return CommandResult.helpCommandResult(SHOWING_HELP_MESSAGE);
     }
 }

--- a/src/main/java/seedu/us/among/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ListCommand.java
@@ -9,10 +9,6 @@ import seedu.us.among.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final boolean SHOW_HELP = false;
-    public static final boolean IS_EXIT = false;
-    public static final boolean IS_LIST = true;
-
     public static final String COMMAND_WORD = "list";
 
     private static final String MESSAGE_SUCCESS = "Listed all saved API endpoints on the left-hand-side panel.\n";
@@ -34,8 +30,8 @@ public class ListCommand extends Command {
         requireNonNull(model);
         model.updateFilteredEndpointList(Model.PREDICATE_SHOW_ALL_ENDPOINTS);
         return model.isEndpointListEmpty()
-                ? new CommandResult(MESSAGE_SUCCESS_WITH_EMPTY_LIST, SHOW_HELP, IS_EXIT, IS_LIST)
+                ? CommandResult.listCommandResult(MESSAGE_SUCCESS_WITH_EMPTY_LIST)
                 :
-                new CommandResult(MESSAGE_SUCCESS_WITH_FILLED_LIST, SHOW_HELP, IS_EXIT, IS_LIST);
+                CommandResult.listCommandResult(MESSAGE_SUCCESS_WITH_FILLED_LIST);
     }
 }

--- a/src/main/java/seedu/us/among/logic/commands/RunCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RunCommand.java
@@ -71,11 +71,7 @@ public class RunCommand extends Command {
         Response response = endpointCaller.callEndpoint();
 
         Endpoint endpointWithResponse = new Endpoint(toRun, response);
-        return new CommandResult(endpointWithResponse.getResponseEntity(),
-                endpointWithResponse,
-                false,
-                false,
-                true);
+        return new CommandResult(endpointWithResponse.getResponseEntity(), endpointWithResponse);
     }
 
     @Override

--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -57,11 +57,7 @@ public class SendCommand extends Command {
         Endpoint endpointWithResponse = new Endpoint(endpointToSend, response);
         model.setEndpoint(endpointToSend, endpointWithResponse);
 
-        return new CommandResult(endpointWithResponse.getResponseEntity(),
-                endpointWithResponse,
-                false,
-                false,
-                true);
+        return new CommandResult(endpointWithResponse.getResponseEntity(), endpointWithResponse);
     }
 
     @Override

--- a/src/test/java/seedu/us/among/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/CommandResultTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.us.among.logic.commands.CommandResult.exitCommandResult;
+import static seedu.us.among.logic.commands.CommandResult.helpCommandResult;
+import static seedu.us.among.logic.commands.CommandResult.listCommandResult;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +17,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback")));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,13 +32,13 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
+        assertFalse(commandResult.equals(helpCommandResult("feedback")));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
+        assertFalse(commandResult.equals(exitCommandResult("feedback")));
 
         // different islist value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
+        assertFalse(commandResult.equals(listCommandResult("feedback")));
     }
 
     @Test
@@ -49,13 +52,13 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), helpCommandResult("feedback").hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), exitCommandResult("feedback").hashCode());
 
         // different isList value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), listCommandResult("feedback").hashCode());
 
     }
 }

--- a/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/us/among/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.us.among.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.us.among.logic.commands.CommandResult.listCommandResult;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_DATA;
 import static seedu.us.among.logic.parser.CliSyntax.PREFIX_HEADER;
@@ -113,10 +114,7 @@ public class CommandTestUtil {
      */
     public static void assertListCommandSuccess(ListCommand command, Model actualModel, String expectedMessage,
                                             Model expectedModel) {
-        boolean showHelp = false;
-        boolean isExit = false;
-        boolean isList = true;
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage, showHelp, isExit, isList);
+        CommandResult expectedCommandResult = listCommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
 

--- a/src/test/java/seedu/us/among/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/ExitCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.us.among.logic.commands;
 
+import static seedu.us.among.logic.commands.CommandResult.exitCommandResult;
 import static seedu.us.among.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -8,17 +9,12 @@ import seedu.us.among.model.Model;
 import seedu.us.among.model.ModelManager;
 
 public class ExitCommandTest {
-    public static final boolean SHOW_HELP = false;
-    public static final boolean IS_EXIT = true;
-    public static final boolean IS_LIST = false;
-
     private Model model = new ModelManager();
     private Model expectedModel = new ModelManager();
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                SHOW_HELP, IS_EXIT, IS_LIST);
+        CommandResult expectedCommandResult = exitCommandResult(ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/us/among/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/HelpCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.us.among.logic.commands;
 
+import static seedu.us.among.logic.commands.CommandResult.helpCommandResult;
 import static seedu.us.among.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -8,17 +9,13 @@ import seedu.us.among.model.Model;
 import seedu.us.among.model.ModelManager;
 
 public class HelpCommandTest {
-    public static final boolean SHOW_HELP = true;
-    public static final boolean IS_EXIT = false;
-    public static final boolean IS_LIST = false;
 
     private Model model = new ModelManager();
     private Model expectedModel = new ModelManager();
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(HelpCommand.SHOWING_HELP_MESSAGE,
-                SHOW_HELP, IS_EXIT, IS_LIST);
+        CommandResult expectedCommandResult = helpCommandResult(HelpCommand.SHOWING_HELP_MESSAGE);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Multiple constructors repeat the same logic of attribute assignment and
force various command classes to define boolean variables just for the
sake of creating a command result.

Let's make one main private constructor and respective factory
constructor for specialised command results.

This helps remove all boolean attributes when creating a command result.

While it may not be the best practice (Enum could be used), the setting
of boolean attributes are within commandResult and hence less likely to
result in mistaken boolean values.

Fixes: #415 