### PR TITLE
Fix: minor fix to model and storage component diagrams in DG

### DIFF
--- a/docs/diagrams/BetterModelClassDiagram.puml
+++ b/docs/diagrams/BetterModelClassDiagram.puml
@@ -4,18 +4,21 @@ skinparam arrowThickness 1.1
 skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
-AddressBook *-right-> "1" UniquePersonList
-AddressBook *-right-> "1" UniqueTagList
-UniqueTagList -[hidden]down- UniquePersonList
-UniqueTagList -[hidden]down- UniquePersonList
+EndpointList *-right-> "1" UniqueEndpointList
+EndpointList *-right-> "1" UniqueTagList
+EndpointList *-up-> "1" UniqueHeaderList
+UniqueTagList -[hidden]down- UniqueEndpointList
+UniqueTagList -[hidden]down- UniqueEndpointList
 
 UniqueTagList *-right-> "*" Tag
+UniqueHeaderList *-right-> "*" Header
 UniqueEndpointList o-right-> Endpoint
 
 Endpoint -up-> "*" Tag
+Endpoint -up-> "*" Header
 
 Endpoint *--> Method
 Endpoint *--> Address
 Endpoint *--> Data
-Endpoint *--> Header
+Endpoint *--> Response
 @enduml

--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -20,6 +20,7 @@ Class Endpoint
 Class Address
 Class Data
 Class Method
+Class Response
 Class UniqueEndpointList
 }
 
@@ -48,6 +49,7 @@ UniqueEndpointList o--> "*" Endpoint
 Endpoint *--> "1" Method
 Endpoint *--> "1" Data
 Endpoint *--> "1" Address
+Endpoint *--> "0..1" Response
 Endpoint *--> "*" Header
 Endpoint *--> "*" Tag
 

--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -6,19 +6,19 @@ skinparam classBackgroundColor STORAGE_COLOR
 
 Interface Storage <<Interface>>
 Interface UserPrefsStorage <<Interface>>
-Interface AddressBookStorage <<Interface>>
+Interface EndpointListStorage <<Interface>>
 
 Class StorageManager
 Class JsonUserPrefsStorage
-Class JsonAddressBookStorage
+Class JsonEndpointListStorage
 
 StorageManager .left.|> Storage
 StorageManager o-right-> UserPrefsStorage
-StorageManager o--> AddressBookStorage
+StorageManager o--> EndpointListStorage
 
 JsonUserPrefsStorage .left.|> UserPrefsStorage
-JsonAddressBookStorage .left.|> AddressBookStorage
-JsonAddressBookStorage .down.> JsonSerializableAddressBookStorage
-JsonSerializableAddressBookStorage .right.> JsonSerializablePerson
-JsonSerializablePerson .right.> JsonAdaptedTag
+JsonEndpointListStorage .left.|> EndpointListStorage
+JsonEndpointListStorage .down.> JsonSerializableEndpointListStorage
+JsonSerializableEndpointListStorage .right.> JsonSerializableEndpoint
+JsonSerializableEndpoint .right.> JsonAdaptedTag
 @enduml


### PR DESCRIPTION
Remove AB3 references in model and storage component diagrams.
Add some missing classes.

Resolves #431 