### PR TITLE
Fix: fix quickstart link and acknowledge request library

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ title: imPoster
 
 **imPoster contains most of the features of [Postman](https://www.postman.com/) and is implemented in a simple and minimalistic style** that is easy for anyone to pick up. The latest releases for download are available [here](https://imposter-dev.tk).
 
-* If you are interested in using imPoster, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested in using imPoster, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#3-quickstart).
 * If you are interested about developing imPoster, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 A brief snapshot of our application:
@@ -32,4 +32,4 @@ A brief snapshot of our application:
 
 **Acknowledgements**
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).
-* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5)
+* Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5), [Apache HttpComponents](https://hc.apache.org/index.html)


### PR DESCRIPTION
Fix quickstart link in index page.
Add Apache HttpComponents to acknowledgements.

Closes #443 