### PR TITLE
Docs: fix broken links in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -24,13 +24,13 @@ nav-text: User Guide
 
 ## 1. Welcome to imPoster
 
-Are you an aspiring [**Application Programming Interface (API)**](#7-glossary) developer? Or would you like a peek into the world of how applications communicate with one another? Then **imPoster** is the app just for you! But hold on, what is imPoster?
+Are you an aspiring [**Application Programming Interface (API)**](#glossary-api) developer? Or would you like a peek into the world of how applications communicate with one another? Then **imPoster** is the app just for you! But hold on, what is imPoster?
 
 imPoster is a desktop application for beginners of API development to quickly go hands-on with the basics. Whether you are looking to **explore**, **test**, or **build** your very own APIs, the simple and minimalistic style of imPoster will quickly get you up and going.
 
 This user guide assumes that users have a **basic understanding** of APIs. If you are wondering [what an API is](#81-what-is-an-api), an appendix has been provided for users who may be unfamiliar with the concept. However, it is highly recommended for users to refer to proper tutorial contents for the basics of APIs prior to using the application.
 
-For fast typists, imPoster is also highly optimised for the command line and can be fully operated through keyboard commands. Users who are familiar with [**CURL**](#7-glossary) will also be happy to know that we share a very similar command line syntax. If you have yet to do so, be sure to download our [latest releases](https://imposter-dev.tk) from our main website and give us a try!
+For fast typists, imPoster is also highly optimised for the command line and can be fully operated through keyboard commands. Users who are familiar with [**CURL**](#glossary-curl) will also be happy to know that we share a very similar command line syntax. If you have yet to do so, be sure to download our [latest releases](https://imposter-dev.tk) from our main website and give us a try!
 
 <div style="page-break-after: always;"></div>
 
@@ -57,8 +57,7 @@ Before diving into the rest of the contents in our user guide, the following are
 
 1. Ensure you have **Java 11 or above** installed on your Computer.
 
-2. Download the latest **imposter.jar** from
-   [here](https://imposter-dev.tk) and move the file to the folder you wish to use as the **home folder** for imPoster.
+2. Download the latest **imposter.jar** from [here](https://imposter-dev.tk) and move the file to the folder you wish to use as the **home folder** for imPoster.
 
 3. **Double-click** the file to start the application. A graphical user interface (GUI) containing the annotated **3 main components** should show up as below:<br>
 
@@ -66,7 +65,7 @@ Before diving into the rest of the contents in our user guide, the following are
       <img width="900px" src="images/startscreen.png" >
     </p>
 
-4. Try making your first API call through our application with the first [**endpoint**](#7-glossary) shown in the default **Endpoint List**. Type <span class="main-command">send</span> <span class="compulsory-param">1</span> in the **Command Box** and then press <kbd>Enter</kbd>.
+4. Try making your first API call through our application with the first [**endpoint**](#glossary-endpoint) shown in the default **Endpoint List**. Type <span class="main-command">send</span> <span class="compulsory-param">1</span> in the **Command Box** and then press <kbd>Enter</kbd>.
 
 5. After which, try scrolling through the responses shown in the **Result Display** as well!
 
@@ -80,7 +79,7 @@ Before diving into the rest of the contents in our user guide, the following are
 9. If you are new and unsure of where to find an API endpoint to start, fret not! We have prepared an extensive list of [sample endpoints](#86-sample-endpoints) for you.
 
 <div markdown="span" class="alert alert-danger">:exclamation: **Caution:**
-imPoster will start with an empty file if a modification to the [data file](#5-Frequently-Asked-Questions-FAQ) causes the data to be invalid.
+imPoster will start with an empty file if a modification to the [data file](#data-file) causes the data to be invalid.
 </div>
 
 
@@ -269,7 +268,7 @@ If you wish to generate a set of sample endpoints, you may delete the **imposter
 
 #### 4.2.8 Call a saved API endpoint: `send`
 
-**Description:** [Call](#7-glossary) an API endpoint from the API endpoint list **(an ongoing call can be cancelled with <kbd>ctrl</kbd> + <kbd>d</kbd>)**.
+**Description:** [Call](#glossary-call) an API endpoint from the API endpoint list **(an ongoing call can be cancelled with <kbd>ctrl</kbd> + <kbd>d</kbd>)**.
 
 **Format** <span class="main-command">send</span> <span class="compulsory-param">INDEX</span>
 
@@ -281,7 +280,7 @@ If you wish to generate a set of sample endpoints, you may delete the **imposter
 
 #### 4.2.9 Call an API endpoint directly without saving: `run`
 
-**Description:** [Call](#7-glossary) an API endpoint directly (without saving) **(an ongoing call can be cancelled with <kbd>ctrl</kbd> + <kbd>d</kbd>)**.
+**Description:** [Call](#glossary-call) an API endpoint directly (without saving) **(an ongoing call can be cancelled with <kbd>ctrl</kbd> + <kbd>d</kbd>)**.
 
 **Format:** <span class="main-command">run</span> <span class="compulsory-param">-x METHOD</span> <span class="compulsory-param">-u URL</span> <span class="optional-param">-d DATA</span> <span class="optional-param">[-h HEADER]</span>
 
@@ -322,13 +321,13 @@ command box with the last command.
 
 #### 4.3.4 Error Messages
 
-**Description:** Do not worry if you input any commands wrongly when using our app! Our app gives helpful error messages depending on the command you entered and you can always enter the [**help command**](#4.1.1-View-help) if you need to refer back to the various commands available!
+**Description:** Do not worry if you input any commands wrongly when using our app! Our app gives helpful error messages depending on the command you entered and you can always enter the [**help command**](#411-view-help-help) if you need to refer back to the various commands available!
 
 <div style="page-break-after: always;"></div>
 
 ## 5. Frequently Asked Questions (FAQ)
 
-**Q**: I am completely new to APIs, how do I get an [endpoint](#7-glossary)?
+**Q**: I am completely new to APIs, how do I get an [endpoint](#glossary-endpoint)?
 <br/><br/>
 **A**: While the use of APIs is commonplace, not all applications provide their API endpoints publicly. **Google** is your best friend for searching of public APIs but if you are new and just looking to try things out, fear not! We have prepared an extensive list of [sample endpoints](#86-sample-endpoints) to get you started!
 
@@ -342,6 +341,7 @@ with the file that contains the data of your previous imPoster home folder.
 <br/><br/>
 **A**: This current version of imPoster only supports the sending of [JSON](#85-json-format) data in the request body which is the format used by an estimated over 70% of APIs worldwide. We apologise for the inconvenience caused but we are happy to share that plans are in place to include support for other data formats in future versions!
 
+<a name="data-file"></a>
 **Q**: Where are the data of imPoster saved?
 <br/><br/>
 **A**: imPoster data are saved automatically into a JSON file named `<JAR file location>/data/imposter.json` after any command that changes the data.
@@ -380,15 +380,15 @@ A quick overview of all supported commands, their formats and examples are given
 
 | Term                                         | Description                                               |
 | -------------------------------------------- | --------------------------------------------------------- |
-| **API** | API is short for **Application Programming Interface** and allows two systems to interact with each other  |
-| **Call** | A call to an API endpoint refers to the process of sending a [request to the server and then receiving a response](#83-what-are-requests-and-responses).           |
-| **Endpoint** | The communication point of a system that allows it to interact with another system, commonly accessed through a URL |
+| **API** | <a name="glossary-api"></a> API is short for **Application Programming Interface** and allows two systems to interact with each other  |
+| **Call** | <a name="glossary-call"></a> A call to an API endpoint refers to the process of sending a [request to the server and then receiving a response](#83-what-are-requests-and-responses).          |
+| **Endpoint** | <a name="glossary-endpoint"></a> The communication point of a system that allows it to interact with another system, commonly accessed through a URL |
 | **Request** | A process in which information is sent out to an endpoint through one of the [request methods](#84-request-methods) (a more detailed explanation can be found [here](#83-what-are-requests-and-responses)) |
 | **Response** | The information obtained from an endpoint after a request is sent to it (a more detailed explanation can be found [here](#83-what-are-requests-and-responses)) |
 | **Parameter**   | Information passed in as part of a command with its type identified by a prefix (e.g. <span class="compulsory-param">METHOD</span>) |
 | **Prefix**   | Characters used to identify the following parameter (e.g. <span class="compulsory-param">-x</span> is the prefix for the parameter <span class="compulsory-param">METHOD</span>) |
 | **JSON** | JSON is short for **JavaScript Object Notation** which is a lightweight format for data storage (a more detailed explanation can be found [here](#85-json-format)) |
-| **CURL** | CURL is short for **Client URL** and is a command-line tool used in the transfer of data via different network protocols |
+| **CURL** | <a name="glossary-curl"></a> CURL is short for **Client URL** and is a command-line tool used in the transfer of data via different network protocols |
 | **Index** | Index in this guide refers to the position of the endpoint in the endpoint list (represented by the number beside the endpoint) |
 
 <div style="page-break-after: always;"></div>
@@ -403,7 +403,7 @@ Broadly speaking, an **API** is an interface that enables and defines how **two 
   <img width="700px" src="images/ApiExplanation.png" >
 </p>
 
-Note that for the **waiter** to pass the order to the **kitchen**, a **window/door** is required to allow communication and this is represented by the term [**endpoint**](#7-glossary) which is frequently used in relation to an API.
+Note that for the **waiter** to pass the order to the **kitchen**, a **window/door** is required to allow communication and this is represented by the term [**endpoint**](#glossary-endpoint) which is frequently used in relation to an API.
 
 <div style="page-break-after: always;"></div>
 
@@ -416,7 +416,7 @@ You may be surprised to know that APIs are not only widely used in our daily liv
 The terms **requests** and **responses** both refer to messages used in the exchange of information between two systems (sender and receiver). Typically, the sender will send out a request containing information to be sent to the receiver. Then, when the receiver receives the request from the sender, it will process the request and send back a response. This response is then received and processed by the original sender, thus completing a single API call.
 
 ### 8.4 Request Methods
-As of the latest version of our application, we support 7 commonly used request methods. We recommend individuals who are interested to learn more about request types to refer to [official documentation](#https://webconcepts.info/concepts/http-method/). A brief explanation for the 7 supported requests have been provided below:
+As of the latest version of our application, we support 7 commonly used request methods. We recommend individuals who are interested to learn more about request types to refer to [official documentation](https://webconcepts.info/concepts/http-method/). A brief explanation for the 7 supported requests have been provided below:
 
 | Method      | Description                                                                                                 |
 | ----------- | ----------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fix a few broken links.
Improve links in glossary to go to the specific term.

Closes #466 