### PR TITLE
Fix: standardise connection/unknownhost error messages to minimize confusion

### DIFF
--- a/src/main/java/seedu/us/among/commons/core/Messages.java
+++ b/src/main/java/seedu/us/among/commons/core/Messages.java
@@ -10,8 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX =
              "The API endpoint index provided is invalid or out of bounds.";
     public static final String MESSAGE_ENDPOINTS_LISTED_OVERVIEW = "%1$d API endpoints listed!";
-    public static final String MESSAGE_UNKNOWN_HOST = "The host name could not be resolved. Check your"
-            + " internet connection and endpoint URL.";
     public static final String MESSAGE_INVALID_JSON = "The request was not performed successfully. Check"
             + " that your data is added in the correct JSON format.";
     public static final String MESSAGE_CONNECTION_ERROR = "Connection was lost or could not be established."

--- a/src/main/java/seedu/us/among/logic/request/EndpointCaller.java
+++ b/src/main/java/seedu/us/among/logic/request/EndpointCaller.java
@@ -4,7 +4,6 @@ import static seedu.us.among.commons.core.Messages.MESSAGE_CALL_CANCELLED;
 import static seedu.us.among.commons.core.Messages.MESSAGE_CONNECTION_ERROR;
 import static seedu.us.among.commons.core.Messages.MESSAGE_GENERAL_ERROR;
 import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_JSON;
-import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_HOST;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -64,16 +63,14 @@ public class EndpointCaller {
 
         try {
             response = sendRequest();
-        } catch (UnknownHostException e) {
-            logger.warning(StringUtil.getDetails(e));
-            throw new RequestException(MESSAGE_UNKNOWN_HOST);
         } catch (ClientProtocolException | SocketTimeoutException | SocketException e) {
             logger.warning(StringUtil.getDetails(e));
             throw new RequestException(MESSAGE_CONNECTION_ERROR);
         } catch (JsonParseException e) {
             logger.warning(StringUtil.getDetails(e));
             throw new RequestException(MESSAGE_INVALID_JSON);
-        } catch (IllegalStateException | SSLException | NoHttpResponseException | InterruptedIOException e) {
+        } catch (IllegalStateException | SSLException | NoHttpResponseException | InterruptedIOException
+                | UnknownHostException e) {
             logger.warning(StringUtil.getDetails(e));
             if (requestAborted) {
                 throw new AbortRequestException(MESSAGE_CALL_CANCELLED);


### PR DESCRIPTION
UnknownHostException and ConnectException now shows the same message to minimise confusion.

Note: This generic error message will be improved by @tlylt in a future PR.

Fixes #532 