### PR TITLE
Update integer parsing and show command fixes

### DIFF
--- a/src/main/java/seedu/us/among/commons/core/Messages.java
+++ b/src/main/java/seedu/us/among/commons/core/Messages.java
@@ -7,8 +7,11 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX =
-             "The API endpoint index provided is invalid or out of bounds.";
+    public static final String MESSAGE_INVALID_COMMAND_ERROR = "Error: %1$s\n%2$s";
+    public static final String MESSAGE_INDEX_NOT_WITHIN_LIST =
+             "Index provided is not within the saved endpoint list.\n";
+    public static final String MESSAGE_INVALID_INDEX = "Index provided is not a non-zero unsigned integer within the "
+            + "allowed range.\n";
     public static final String MESSAGE_ENDPOINTS_LISTED_OVERVIEW = "%1$d API endpoints listed!";
     public static final String MESSAGE_INVALID_JSON = "The request was not performed successfully. Check"
             + " that your data is added in the correct JSON format.";

--- a/src/main/java/seedu/us/among/commons/util/StringUtil.java
+++ b/src/main/java/seedu/us/among/commons/util/StringUtil.java
@@ -5,6 +5,7 @@ import static seedu.us.among.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -74,7 +75,7 @@ public class StringUtil {
     }
 
     /**
-     * Returns true if {@code s} represents a non-zero unsigned integer
+     * Returns true if {@code s} represents a non-zero unsigned integer, without causing integer overflow or underflow
      * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
      * Will return false for any other non-null string input
      * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
@@ -82,10 +83,13 @@ public class StringUtil {
      */
     public static boolean isNonZeroUnsignedInteger(String s) {
         requireNonNull(s);
-
         try {
-            int value = Integer.parseInt(s);
-            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+            BigInteger value = new BigInteger(s);
+            return !(value.compareTo(BigInteger.ZERO) == 0)
+                    && (value.compareTo(BigInteger.ZERO) > 0)
+                    && (value.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) <= 0)
+                    && (value.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) >= 0)
+                    && !s.startsWith("+"); // "+1" is successfully parsed by new BigInteger(String)
         } catch (NumberFormatException nfe) {
             return false;
         }
@@ -137,5 +141,6 @@ public class StringUtil {
 
         return sb.toString().trim();
     }
+
 
 }

--- a/src/main/java/seedu/us/among/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/EditCommand.java
@@ -108,7 +108,7 @@ public class EditCommand extends Command {
         List<Endpoint> lastShownList = model.getFilteredEndpointList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
         }
 
         Endpoint endpointToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/us/among/logic/commands/RemoveCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/RemoveCommand.java
@@ -36,7 +36,7 @@ public class RemoveCommand extends Command {
         List<Endpoint> lastShownList = model.getFilteredEndpointList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
         }
 
         Endpoint endpointToRemove = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/us/among/logic/commands/SendCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/SendCommand.java
@@ -47,7 +47,7 @@ public class SendCommand extends Command {
         List<Endpoint> lastShownList = model.getFilteredEndpointList();
         if (index.getZeroBased() >= lastShownList.size()) {
             logger.info("Illegal index found, out of bound");
-            throw new CommandException(Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
         }
 
         Endpoint endpointToSend = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/us/among/logic/commands/ShowCommand.java
+++ b/src/main/java/seedu/us/among/logic/commands/ShowCommand.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_ERROR;
 
 import java.util.List;
 
@@ -19,8 +20,8 @@ public class ShowCommand extends Command {
     public static final String COMMAND_WORD = "show";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the details of an existing API endpoint "
-            + "identified using it's displayed index from the API endpoint list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + "identified using its displayed index from the saved endpoint list.\n"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1 ";
 
     private final Index index;
@@ -39,7 +40,9 @@ public class ShowCommand extends Command {
         requireNonNull(model);
         List<Endpoint> lastShownList = model.getFilteredEndpointList();
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+            throw new CommandException(String.format(MESSAGE_INVALID_COMMAND_ERROR,
+                    Messages.MESSAGE_INDEX_NOT_WITHIN_LIST,
+                    ShowCommand.MESSAGE_USAGE));
         }
 
         Endpoint endpointToShow = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/us/among/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/us/among/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_INDEX;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -21,7 +22,7 @@ import seedu.us.among.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading

--- a/src/main/java/seedu/us/among/logic/parser/ShowCommandParser.java
+++ b/src/main/java/seedu/us/among/logic/parser/ShowCommandParser.java
@@ -1,6 +1,6 @@
 package seedu.us.among.logic.parser;
 
-import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_ERROR;
 
 import java.util.logging.Logger;
 
@@ -28,7 +28,8 @@ public class ShowCommandParser implements Parser<ShowCommand> {
             return new ShowCommand(index);
         } catch (ParseException pe) {
             logger.warning(StringUtil.getDetails(pe));
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ShowCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_ERROR, pe.getMessage(),
+                    ShowCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/test/java/seedu/us/among/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/us/among/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.us.among.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INDEX_NOT_WITHIN_LIST;
 import static seedu.us.among.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.us.among.logic.commands.CommandTestUtil.ADDRESS_DESC_RANDOM;
 import static seedu.us.among.logic.commands.CommandTestUtil.DATA_DESC_DEFAULT;
@@ -61,7 +61,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "remove 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/EditCommandTest.java
@@ -133,7 +133,7 @@ public class EditCommandTest {
         EditEndpointDescriptor descriptor = new EditEndpointDescriptorBuilder().withMethod(VALID_METHOD_POST).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     /**
@@ -150,7 +150,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditEndpointDescriptorBuilder().withMethod(VALID_METHOD_POST).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/commands/RemoveCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/RemoveCommandTest.java
@@ -45,7 +45,7 @@ public class RemoveCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEndpointList().size() + 1);
         RemoveCommand removeCommand = new RemoveCommand(outOfBoundIndex);
 
-        assertCommandFailure(removeCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(removeCommand, model, Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class RemoveCommandTest {
 
         RemoveCommand removeCommand = new RemoveCommand(outOfBoundIndex);
 
-        assertCommandFailure(removeCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(removeCommand, model, Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/commands/SendCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/SendCommandTest.java
@@ -55,7 +55,7 @@ public class SendCommandTest {
     public void execute_outOfBoundEndpointIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEndpointList().size() + 1);
         SendCommand sendCommand = new SendCommand(outOfBoundIndex);
-        assertCommandFailure(sendCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(sendCommand, model, Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class SendCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getEndpointList().getEndpointList().size());
 
         assertCommandFailure(new SendCommand(outOfBoundIndex), model,
-                Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+                Messages.MESSAGE_INDEX_NOT_WITHIN_LIST);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/commands/ShowCommandTest.java
+++ b/src/test/java/seedu/us/among/logic/commands/ShowCommandTest.java
@@ -3,6 +3,8 @@ package seedu.us.among.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INDEX_NOT_WITHIN_LIST;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_ERROR;
 import static seedu.us.among.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.us.among.logic.commands.CommandTestUtil.showEndpointAtIndex;
 import static seedu.us.among.testutil.Assert.assertThrows;
@@ -12,7 +14,6 @@ import static seedu.us.among.testutil.TypicalIndexes.INDEX_SECOND_ENDPOINT;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.us.among.commons.core.Messages;
 import seedu.us.among.commons.core.index.Index;
 import seedu.us.among.logic.commands.exceptions.CommandException;
 import seedu.us.among.model.Model;
@@ -20,6 +21,8 @@ import seedu.us.among.model.ModelManager;
 import seedu.us.among.model.UserPrefs;
 
 public class ShowCommandTest {
+    private static final String MESSAGE_INVALID_FORMAT_OUT_OF_BOUND = String.format(MESSAGE_INVALID_COMMAND_ERROR,
+            MESSAGE_INDEX_NOT_WITHIN_LIST, ShowCommand.MESSAGE_USAGE);
 
     private Model model = new ModelManager(getTypicalEndpointList(), new UserPrefs());
 
@@ -37,7 +40,7 @@ public class ShowCommandTest {
     public void execute_outOfBoundEndpointIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEndpointList().size() + 1);
         ShowCommand showCommand = new ShowCommand(outOfBoundIndex);
-        assertCommandFailure(showCommand, model, Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+        assertCommandFailure(showCommand, model, MESSAGE_INVALID_FORMAT_OUT_OF_BOUND);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class ShowCommandTest {
         assertTrue(outOfBoundIndex.getZeroBased() < model.getEndpointList().getEndpointList().size());
 
         assertCommandFailure(new ShowCommand(outOfBoundIndex), model,
-                Messages.MESSAGE_INVALID_ENDPOINT_DISPLAYED_INDEX);
+                MESSAGE_INVALID_FORMAT_OUT_OF_BOUND);
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/ParserUtilTest.java
@@ -3,8 +3,6 @@ package seedu.us.among.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.us.among.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
-import static seedu.us.among.testutil.Assert.assertThrows;
 import static seedu.us.among.testutil.TypicalIndexes.INDEX_FIRST_ENDPOINT;
 
 import java.util.Arrays;
@@ -47,9 +45,8 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseIndex_outOfRangeInput_throwsParseException() throws Exception {
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test

--- a/src/test/java/seedu/us/among/logic/parser/ShowCommandParserTest.java
+++ b/src/test/java/seedu/us/among/logic/parser/ShowCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.us.among.logic.parser;
 
-import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_COMMAND_ERROR;
+import static seedu.us.among.commons.core.Messages.MESSAGE_INVALID_INDEX;
 import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.us.among.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.us.among.testutil.TypicalIndexes.INDEX_SECOND_ENDPOINT;
@@ -12,21 +13,21 @@ import seedu.us.among.logic.commands.ShowCommand;
 
 public class ShowCommandParserTest {
 
-    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-            ShowCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_FORMAT_NAN = String.format(MESSAGE_INVALID_COMMAND_ERROR,
+            MESSAGE_INVALID_INDEX, ShowCommand.MESSAGE_USAGE);
 
     private ShowCommandParser parser = new ShowCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT_NAN);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1c", MESSAGE_INVALID_FORMAT); // invalid number
-        assertParseFailure(parser, "one", MESSAGE_INVALID_FORMAT); // invalid number (should be numeric)
+        assertParseFailure(parser, "1c", MESSAGE_INVALID_FORMAT_NAN); // invalid number
+        assertParseFailure(parser, "one", MESSAGE_INVALID_FORMAT_NAN); // invalid number (should be numeric)
     }
 
     @Test


### PR DESCRIPTION
- use BigInteger to parse string input for index
- show command error message has been updated as follows:
- will proceed to update other command error messages such that cause of error is shown in the first line, followed by a standard command usage note
- fixes #498 , fixes #485
![](http://g.recordit.co/RYSOB1iFaj.gif)
